### PR TITLE
68 implement network relation transisthor

### DIFF
--- a/Client/ClientRoom.cpp
+++ b/Client/ClientRoom.cpp
@@ -1,6 +1,6 @@
 /*
 ** EPITECH PROJECT, 2022
-** Project
+** R-Type
 ** File description:
 ** Client
 */

--- a/Client/ClientRoom.cpp
+++ b/Client/ClientRoom.cpp
@@ -48,9 +48,6 @@ void ClientRoom::startLobbyLoop(void)
     while (_state != ClientState::ENDED && _state != ClientState::UNDEFINED) {
         try {
             connexionResponse = _communicatorInstance.get()->getLastMessage();
-            if (connexionResponse.message.type == 30)
-                std::cerr << "Component succesfully received."
-                          << std::endl; /// USED FOR FUNCTIONAL TESTING, WILL BE REMOVED LATER
             std::cerr << "ClientRoom received a connexion protocol answer."
                       << std::endl; /// WILL BE DELETED WITH CONNEXION PROTOCOL ISSUE
         } catch (NetworkError &error) {

--- a/Client/ClientRoom.hpp
+++ b/Client/ClientRoom.hpp
@@ -1,6 +1,6 @@
 /*
 ** EPITECH PROJECT, 2022
-** Project
+** R-Type
 ** File description:
 ** Client
 */

--- a/Server/Room.cpp
+++ b/Server/Room.cpp
@@ -1,6 +1,6 @@
 /*
 ** EPITECH PROJECT, 2022
-** Project
+** R-Type
 ** File description:
 ** Room
 */

--- a/Server/Room.hpp
+++ b/Server/Room.hpp
@@ -1,6 +1,6 @@
 /*
 ** EPITECH PROJECT, 2022
-** Project
+** R-Type
 ** File description:
 ** Room
 */

--- a/Server/Server.cpp
+++ b/Server/Server.cpp
@@ -1,6 +1,6 @@
 /*
 ** EPITECH PROJECT, 2022
-** Project
+** R-Type
 ** File description:
 ** Server
 */

--- a/Server/Server.hpp
+++ b/Server/Server.hpp
@@ -1,6 +1,6 @@
 /*
 ** EPITECH PROJECT, 2022
-** Project
+** R-Type
 ** File description:
 ** Server
 */

--- a/libs/Communicator/Communicator.cpp
+++ b/libs/Communicator/Communicator.cpp
@@ -59,6 +59,7 @@ CommunicatorMessage Communicator::getLastMessage(void)
     try {
         Message lastMessage = _receiverModule.getLastMessage();
         receiveProtocol2X(lastMessage);
+        receiveProtocol3X(lastMessage);
         try {
             addClientToList(lastMessage.clientInfo);
             return CommunicatorMessage{lastMessage, true};
@@ -129,6 +130,14 @@ void Communicator::receiveProtocol2X(Message lastMessage)
         replaceClientByAnother(_receiverModule.getLastMessage().clientInfo, lastMessage.clientInfo);
         std::cerr << "You have been asked to switch to a new communicator." << std::endl;
         _senderModule.sendDataToAClient(lastMessage.clientInfo, nullptr, 0, 21);
+    }
+}
+
+void Communicator::receiveProtocol3X(Message lastMessage)
+{
+    if (lastMessage.type == 30) {
+        _transisthorBridge.get()->transitNetworkDataToEcsData(lastMessage);
+        throw NetworkError("No message waiting for traitment.", "Communicator.cpp -> getLastMessage");
     }
 }
 

--- a/libs/Communicator/Communicator.hpp
+++ b/libs/Communicator/Communicator.hpp
@@ -119,6 +119,10 @@ namespace communicator_lib
         /// @param lastMessage The message to trait
         void receiveProtocol2X(Message lastMessage);
 
+        /// @brief If the data type is 3X, the function will process the data following the 3X protocol
+        /// @param lastMessage Message to trait
+        void receiveProtocol3X(Message lastMessage);
+
         /// @brief Replace a client in the memory by another
         /// @param oldClient The oldest client to replace
         /// @param newClient to replace with

--- a/libs/Transisthor/Transisthor.cpp
+++ b/libs/Transisthor/Transisthor.cpp
@@ -50,6 +50,7 @@ void *Transisthor::transitNetworkDataToEcsData(Message networkData)
     object = (void *)((char *)networkData.data + sizeof(unsigned short) * 2);
     if (_componentConvertFunctionList.find(type) == _componentConvertFunctionList.end())
         return object; /// THROW ERROR INVALID TYPE
+    std::cerr << "A component have been transfered to ECS" << std::endl; /// ONLY USE FOR FUNCTIONAL TESTING
     _componentConvertFunctionList[type](id, object);
     return object; /// ONLY USED FOR UNIT TESTING
 }

--- a/libs/Transisthor/Transisthor.cpp
+++ b/libs/Transisthor/Transisthor.cpp
@@ -52,7 +52,7 @@ void *Transisthor::transitNetworkDataToEcsData(Message networkData)
         return object;                                                   /// THROW ERROR INVALID TYPE
     std::cerr << "A component have been transfered to ECS" << std::endl; /// ONLY USE FOR FUNCTIONAL TESTING
     _componentConvertFunctionList[type](id, object);
-    return object; /// ONLY USED FOR UNIT TESTING
+    return object;
 }
 
 void Transisthor::componentConvertDestinationType(unsigned short id, void *byteCode)

--- a/libs/Transisthor/Transisthor.cpp
+++ b/libs/Transisthor/Transisthor.cpp
@@ -49,7 +49,7 @@ void *Transisthor::transitNetworkDataToEcsData(Message networkData)
     std::memcpy(&type, (void *)((char *)networkData.data + sizeof(unsigned short)), sizeof(unsigned short));
     object = (void *)((char *)networkData.data + sizeof(unsigned short) * 2);
     if (_componentConvertFunctionList.find(type) == _componentConvertFunctionList.end())
-        return object; /// THROW ERROR INVALID TYPE
+        return object;                                                   /// THROW ERROR INVALID TYPE
     std::cerr << "A component have been transfered to ECS" << std::endl; /// ONLY USE FOR FUNCTIONAL TESTING
     _componentConvertFunctionList[type](id, object);
     return object; /// ONLY USED FOR UNIT TESTING
@@ -118,7 +118,8 @@ void Transisthor::componentConvertVelocityType(unsigned short id, void *byteCode
     /// SEND THE NEW COMPONENT TO ECS, WILL BE ADDED WHEN TRANSISTHOR WILL BE FULLY IMPLEMENTED
 }
 
-void transisthor_lib::sendDataToAClientWithoutCommunicator(Communicator &communicator, Client &client, void *data, size_t size, unsigned short type)
+void transisthor_lib::sendDataToAClientWithoutCommunicator(
+    Communicator &communicator, Client &client, void *data, size_t size, unsigned short type)
 {
     communicator.sendDataToAClient(client, data, size, type);
 }

--- a/tests/functionnal/Communicator/communicator_send.cpp
+++ b/tests/functionnal/Communicator/communicator_send.cpp
@@ -1,6 +1,6 @@
 /*
 ** EPITECH PROJECT, 2022
-** Project
+** R-Type
 ** File description:
 ** communicator_send
 */


### PR DESCRIPTION
Implement Transisthor call inside Communicator.

When a 3X protocol is received, the message is automatically transferred to the Transisthor.

Update some functional testing to match the new features.

Clean comments and old documentation to match the last version of the transisthor.