### PR TITLE
Rebase SFML library architecture (Interace -> Archive) #103

### DIFF
--- a/libs/SFMLComponents/CMakeLists.txt
+++ b/libs/SFMLComponents/CMakeLists.txt
@@ -12,7 +12,16 @@ set(SRC
     ${SFML_INPUT_INC_ROOT}/ECSActions.hpp
 )
 
-add_library(${TARGET} INTERFACE ${SRC})
+add_library(${TARGET} ${SRC})
+
+target_include_directories(${TARGET}
+    PUBLIC ${SFML_INPUT_INC_ROOT}
+    PUBLIC ${PROJECT_NAME}_ecs
+)
+
+target_link_libraries(${TARGET}
+    ${PROJECT_NAME}_ecs
+)
 
 set_target_properties(${TARGET} PROPERTIES LINKER_LANGUAGE CXX)
 include(${PROJECT_SOURCE_DIR}/build/conanbuildinfo.cmake)


### PR DESCRIPTION
Change the SFML library architecture.

Rebase from INTERFACE to Archive.

(Consider change Include path to current sub-directory to much clearness)