### PR TITLE
Update GraphicsTextureResource  #126

### DIFF
--- a/libs/SFMLResource/GraphicsTextureResource.hpp
+++ b/libs/SFMLResource/GraphicsTextureResource.hpp
@@ -21,7 +21,24 @@ namespace ecs
     class GraphicsTextureResource : public Resource {
       public:
         /// @brief All the possible Textures
-        enum textureName_e { UNDEFINED, PLAYER, PLAYER_UP, PLAYER_DOWN };
+        enum textureName_e {
+            UNDEFINED,
+            PLAYER_STATIC,
+            PLAYER_UP,
+            PLAYER_DOWN,
+            ENEMY_STATIC,
+            ENEMY_UP,
+            ENEMY_DOWN,
+            BACKGROUND_LAYER_1,
+            BACKGROUND_LAYER_2,
+            BACKGROUND_LAYER_3,
+            OBSTACLE_1,
+            OBSTACLE_2,
+            OBSTACLE_3,
+            PROJECTILE,
+            BUTTON,
+            NATURAL_PROJECTILE
+        };
 
         /// @brief Name of map which contains Textures. It's sorted by the name of the Texture and the Texture
         using TexturesList = std::unordered_map<textureName_e, std::shared_ptr<sf::Texture>>;

--- a/libs/SFMLResource/GraphicsTextureResource.hpp
+++ b/libs/SFMLResource/GraphicsTextureResource.hpp
@@ -16,11 +16,10 @@
 namespace ecs
 {
 
-    /// @brief This resource class stores a Graphical SFML texture to be set on a rectangle shape resource.
-    /// This class is created in order to set a texture on a rectangle shape resource.
+    /// @brief This resource class stores a map of Graphical SFML textures to be set on Shapes.
     class GraphicsTextureResource : public Resource {
       public:
-        /// @brief All the possible Textures
+        /// @brief Enumeration of all available Textures
         enum textureName_e {
             UNDEFINED,
             PLAYER_STATIC,
@@ -40,13 +39,11 @@ namespace ecs
             NATURAL_PROJECTILE
         };
 
-        /// @brief Name of map which contains Textures. It's sorted by the name of the Texture and the Texture
+        /// @brief Name of map which contains Textures.
         using TexturesList = std::unordered_map<textureName_e, std::shared_ptr<sf::Texture>>;
 
-        /// @brief Default constructor of the class.
-        GraphicsTextureResource() = default;
-
-        /// @brief Create a texture from the path to an image.
+        /// @brief Add a Texture from it's Texture Path passed as parameter
+        /// @param texture_e Enum of the Texture
         /// @param texturePath The texture path to be used.
         inline GraphicsTextureResource(const textureName_e texture_e, const std::filesystem::path &texturePath)
         {
@@ -55,7 +52,7 @@ namespace ecs
 
         /// @brief Add a texture to the TexturesList
         /// @param texture_e Enum which give the name of the Texture
-        /// @param texturePath Path of the Textrue
+        /// @param texturePath Path of the Texture
         inline void addTexture(const textureName_e texture_e, const std::filesystem::path &texturePath)
         {
             _texturesList.emplace(texture_e, std::make_shared<sf::Texture>()->loadFromFile(texturePath));
@@ -64,7 +61,6 @@ namespace ecs
         /// @brief Default destructor of the class.
         ~GraphicsTextureResource() = default;
 
-      private:
         TexturesList _texturesList;
     };
 } // namespace ecs

--- a/libs/SFMLResource/GraphicsTextureResource.hpp
+++ b/libs/SFMLResource/GraphicsTextureResource.hpp
@@ -8,32 +8,48 @@
 #ifndef GRAPHICSTEXTURERESOURCE_HPP_
 #define GRAPHICSTEXTURERESOURCE_HPP_
 
-#include "Resource/Resource.hpp"
 #include <SFML/Graphics.hpp>
 #include <filesystem>
+#include "Resource/Resource.hpp"
+#include <unordered_map>
 
 namespace ecs
 {
+
     /// @brief This resource class stores a Graphical SFML texture to be set on a rectangle shape resource.
     /// This class is created in order to set a texture on a rectangle shape resource.
     class GraphicsTextureResource : public Resource {
-        public:
-            /// @brief The graphical SFML texture to be set on a rectangle shape resource.
-            sf::Texture texture;
+      public:
+        /// @brief All the possible Textures
+        enum textureName_e { UNDEFINED, PLAYER, PLAYER_UP, PLAYER_DOWN };
 
-            /// @brief Default constructor of the class.
-            GraphicsTextureResource() = default;
+        /// @brief Name of map which contains Textures. It's sorted by the name of the Texture and the Texture
+        using TexturesList = std::unordered_map<textureName_e, std::shared_ptr<sf::Texture>>;
 
-            /// @brief Create a texture from the path to an image.
-            /// @param texturePath The texture path to be used.
-            inline GraphicsTextureResource(const std::filesystem::path &texturePath)
-            {
-                texture.loadFromFile(texturePath);
-            }
+        /// @brief Default constructor of the class.
+        GraphicsTextureResource() = default;
 
-            /// @brief Default destructor of the class.
-            ~GraphicsTextureResource() = default;
+        /// @brief Create a texture from the path to an image.
+        /// @param texturePath The texture path to be used.
+        inline GraphicsTextureResource(const textureName_e texture_e, const std::filesystem::path &texturePath)
+        {
+            addTexture(texture_e, texturePath);
+        }
+
+        /// @brief Add a texture to the TexturesList
+        /// @param texture_e Enum which give the name of the Texture
+        /// @param texturePath Path of the Textrue
+        inline void addTexture(const textureName_e texture_e, const std::filesystem::path &texturePath)
+        {
+            _texturesList.emplace(texture_e, std::make_shared<sf::Texture>()->loadFromFile(texturePath));
+        }
+
+        /// @brief Default destructor of the class.
+        ~GraphicsTextureResource() = default;
+
+      private:
+        TexturesList _texturesList;
     };
-} // namespace
+} // namespace ecs
 
 #endif /* !GRAPHICSTEXTURERESOURCE_HPP_ */

--- a/libs/SFMLResource/GraphicsTextureResource.hpp
+++ b/libs/SFMLResource/GraphicsTextureResource.hpp
@@ -8,10 +8,10 @@
 #ifndef GRAPHICSTEXTURERESOURCE_HPP_
 #define GRAPHICSTEXTURERESOURCE_HPP_
 
-#include <SFML/Graphics.hpp>
 #include <filesystem>
-#include "Resource/Resource.hpp"
 #include <unordered_map>
+#include <SFML/Graphics.hpp>
+#include "Resource/Resource.hpp"
 
 namespace ecs
 {


### PR DESCRIPTION
Create an enum textureName_e which contains all enumeration of textures. Update this resource to store a std::map<textureName_e, std::shared_ptrsf::Texture>. Implement a function which take an enum and a path to add a texture to the map. The constructor can take as parameter an enum and a texture path. The destructor can be set as default.