### PR TITLE
Change addComponent by getComponent #139

### DIFF
--- a/libs/Transisthor/Transisthor.cpp
+++ b/libs/Transisthor/Transisthor.cpp
@@ -383,10 +383,9 @@ void Transisthor::entityConvertAlliedProjectileType(unsigned short id, void *byt
         createNewAlliedProjectile(_ecsWorld, *(shooter.get()), uuid, _ecsWorld.getResource<NetworkableIdGenerator>().generateNewNetworkableId());
     } else {
         std::size_t entityId;
-
         if (uuidStr == "") {
             entityId = createNewAlliedProjectile(_ecsWorld, *(shooter.get()));
-            _ecsWorld.getEntity(entityId).addComponent<Networkable>(id);
+            _ecsWorld.getEntity(entityId).getComponent<Networkable>() = id;
         } else {
             std::vector<std::shared_ptr<Entity>> newlyCreated = _ecsWorld.joinEntities<NewlyCreated>();
 


### PR DESCRIPTION
Fix a crash inside the client executable.

When a second client joined the game and a old AlliedProjectile is send inside the protocol 12, the add inside ECS crashed.

(Change addComponent to getComponent)