### PR TITLE
216 update coverage job on CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -65,7 +65,7 @@ jobs:
       run: ./build.bat
 
   coverage:
-    needs: [build-linux]
+    # needs: [build-linux]
     runs-on: ubuntu-latest
     steps:
       - name: Cache Conan packages
@@ -82,6 +82,7 @@ jobs:
 
       - name: Install criterion
         run: |
+          sudo apt-get install meson
           git clone --recursive https://github.com/Snaipe/Criterion Criterion
           cd Criterion
           meson build

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -88,7 +88,7 @@ jobs:
           meson build
           ninja -C build
           sudo ninja -C build install
-          ldconfig
+          sudo ldconfig
 
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -65,7 +65,7 @@ jobs:
       run: ./build.bat
 
   coverage:
-    # needs: [build-linux]
+    needs: [build-linux]
     runs-on: ubuntu-22.04
     steps:
       - name: Cache Conan packages

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -68,6 +68,11 @@ jobs:
     needs: [build-linux]
     runs-on: ubuntu-22.04
     steps:
+      - name: Dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get upgrade -y
+          sudo apt-get install -y libudev-dev libgl-dev libx11-xcb-dev libfontenc-dev libxaw7-dev libxcomposite-dev libxcursor-dev libxdamage-dev libxfixes-dev libxi-dev libxinerama-dev libxmu-dev libxmuu-dev libxpm-dev libxrandr-dev libxres-dev libxss-dev libxtst-dev libxv-dev libxvmc-dev libxxf86vm-dev libxcb-render-util0-dev libxcb-xkb-dev libxcb-icccm4-dev libxcb-image0-dev libxcb-keysyms1-dev libxcb-randr0-dev libxcb-shape0-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-xinerama0-dev libxcb-dri3-dev
       - name: Cache Conan packages
         id: cache_coverage
         uses: actions/cache@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,13 +73,6 @@ jobs:
           sudo apt-get update -y
           sudo apt-get upgrade -y
           sudo apt-get install -y libudev-dev libgl-dev libx11-xcb-dev libfontenc-dev libxaw7-dev libxcomposite-dev libxcursor-dev libxdamage-dev libxfixes-dev libxi-dev libxinerama-dev libxmu-dev libxmuu-dev libxpm-dev libxrandr-dev libxres-dev libxss-dev libxtst-dev libxv-dev libxvmc-dev libxxf86vm-dev libxcb-render-util0-dev libxcb-xkb-dev libxcb-icccm4-dev libxcb-image0-dev libxcb-keysyms1-dev libxcb-randr0-dev libxcb-shape0-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-xinerama0-dev libxcb-dri3-dev
-      - name: Cache Conan packages
-        id: cache_coverage
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.conan
-          key: ${{ runner.os }}-coverage
 
       - name: Install Conan
         id: conan

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -66,7 +66,7 @@ jobs:
 
   coverage:
     # needs: [build-linux]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Cache Conan packages
         id: cache_coverage

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,14 +67,30 @@ jobs:
   coverage:
     needs: [build-linux]
     runs-on: ubuntu-latest
-    container:
-      image: epitechcontent/epitest-docker
     steps:
+      - name: Cache Conan packages
+        id: cache_coverage
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.conan
+          key: ${{ runner.os }}-coverage
+
       - name: Install Conan
         id: conan
         uses: turtlebrowser/get-conan@main
 
-      - uses: actions/checkout@v2
+      - name: Install criterion
+        run: |
+          git clone --recursive https://github.com/Snaipe/Criterion Criterion
+          cd Criterion
+          meson build
+          ninja -C build
+          sudo ninja -C build install
+          ldconfig
+
+      - name: Checkout Repository
+        uses: actions/checkout@v2
 
       - name: Build tests
         run: ./build_tests.sh

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,6 +82,7 @@ jobs:
 
       - name: Install criterion
         run: |
+          sudo apt-get install gcovr
           sudo apt-get install meson
           git clone --recursive https://github.com/Snaipe/Criterion Criterion
           cd Criterion

--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,4 @@ tests/R-Type_communicator_send
 #Documentation
 docs/html
 CMakeGraphVizOptions.cmake
-coverage.html
+coverage

--- a/build_tests.sh
+++ b/build_tests.sh
@@ -38,5 +38,5 @@ ctest --output-on-failure
 testExitStatus $? "run ctest"
 
 # Create coverage html graph
-cd .. && gcovr --html coverage.html
+cd ..; mkdir -p coverage; gcovr --html-details coverage/coverage.html --exclude tests
 testExitStatus $? "create html coverage"


### PR DESCRIPTION
## Updated features
- Use new ubuntu version (22.04) instead of latest on coverage job on CI.
- Install criterion manually on coverage job on CI instead of epitest container
- Cache conan on coverage job on CI
- Create better html coverage report when using build_tests.sh