### PR TITLE
Make shared resources usable in threads

### DIFF
--- a/libs/ECS/Resource/Resource.hpp
+++ b/libs/ECS/Resource/Resource.hpp
@@ -7,15 +7,20 @@
 
 #pragma once
 
+#include <mutex>
 
 namespace ecs
 {
     /// @brief This is the Resource Class for ECS
     /// The base Resource type, all Resources must inherit from Resource.
-    class Resource {
+    /// The std::mutex inheritance is in order to allows to lock a Resource when something wants to use/modify it
+    class Resource : public std::mutex {
       public:
         /// @brief This is the default destructor of Resource Class
         virtual ~Resource() = default;
+
+        ///@brief Delete the copy constructor because a mutex can't be copied
+        Resource(const Resource &) = delete;
 
       protected:
         /// @brief This is the constructor of Resource Class

--- a/libs/ECS/Resource/Resource.hpp
+++ b/libs/ECS/Resource/Resource.hpp
@@ -13,7 +13,7 @@ namespace ecs
 {
     /// @brief This is the Resource Class for ECS
     /// The base Resource type, all Resources must inherit from Resource.
-    /// The std::mutex inheritance is in order to allows to lock a Resource when something wants to use/modify it
+    /// The std::mutex inheritance is in order to allow to lock a Resource when something wants to use/modify it
     class Resource : public std::mutex {
       public:
         /// @brief This is the default destructor of Resource Class


### PR DESCRIPTION
## Purpose:
At the end of this issues, a shared resource must be usable in threads. This means that it can only be used and modified by only one thread at a time.

## Added features
- The Resource class can now be locked when used or modified in threads.

This will close #238 