### PR TITLE
244 fix sfml component namespace

### DIFF
--- a/Client/ClientRoom.cpp
+++ b/Client/ClientRoom.cpp
@@ -48,6 +48,7 @@ using namespace error_lib;
 using namespace communicator_lib;
 using namespace client_data;
 using namespace ecs;
+using namespace graphicECS::SFML::Components;
 
 static ClientRoom::ClientState *clientRoomState(nullptr);
 

--- a/libs/GraphicECS/SFML/Components/ActionQueueComponent.hpp
+++ b/libs/GraphicECS/SFML/Components/ActionQueueComponent.hpp
@@ -19,7 +19,7 @@ namespace graphicECS::SFML::Components
     /// These functions will be added when an input occurs during the game by a system.
     /// They will be used by another system.
     /// These function are stored in ECSActions.hpp
-    class ActionQueueComponent : public Component {
+    class ActionQueueComponent : public ecs::Component {
       public:
         /// @brief This action queue stores function that will be called in a system and added by another one when
         /// inputs occur.

--- a/libs/GraphicECS/SFML/Components/ActionQueueComponent.hpp
+++ b/libs/GraphicECS/SFML/Components/ActionQueueComponent.hpp
@@ -13,7 +13,7 @@
 #include "Component/Component.hpp"
 #include "World/World.hpp"
 
-namespace ecs
+namespace graphicECS::SFML::Components
 {
     /// @brief This component class stores a function queue.
     /// These functions will be added when an input occurs during the game by a system.
@@ -24,7 +24,7 @@ namespace ecs
         /// @brief This action queue stores function that will be called in a system and added by another one when
         /// inputs occur.
         // std::queue<std::function<void(World &, float)>> actions;
-        enum inputAction_e {UNDEFINED, MOVEX, MOVEY, SHOOT, BUTTON_CLICK, MAX_ACTION};
+        enum inputAction_e { UNDEFINED, MOVEX, MOVEY, SHOOT, BUTTON_CLICK, MAX_ACTION };
         std::queue<std::pair<inputAction_e, float>> actions;
         /// @brief Default constructor.
         ActionQueueComponent() = default;
@@ -32,6 +32,6 @@ namespace ecs
         /// @brief Default destructor.
         ~ActionQueueComponent() = default;
     };
-} // namespace ecs
+} // namespace graphicECS::SFML::Components
 
 #endif /* !ACTIONQUEUECOMPONENT_HPP_ */

--- a/libs/GraphicECS/SFML/Components/AllowControllerComponent.hpp
+++ b/libs/GraphicECS/SFML/Components/AllowControllerComponent.hpp
@@ -10,10 +10,10 @@
 
 #include "Component/Component.hpp"
 
-namespace ecs
+namespace graphicECS::SFML::Components
 {
     /// @brief This component class allows controller usage in client.
     class AllowControllerComponent : public Component {};
-} // namespace ecs
+} // namespace graphicECS::SFML::Components
 
 #endif /* !ALLOWCONTROLLERCOMPONENT_HPP_ */

--- a/libs/GraphicECS/SFML/Components/AllowControllerComponent.hpp
+++ b/libs/GraphicECS/SFML/Components/AllowControllerComponent.hpp
@@ -13,7 +13,7 @@
 namespace graphicECS::SFML::Components
 {
     /// @brief This component class allows controller usage in client.
-    class AllowControllerComponent : public Component {};
+    class AllowControllerComponent : public ecs::Component {};
 } // namespace graphicECS::SFML::Components
 
 #endif /* !ALLOWCONTROLLERCOMPONENT_HPP_ */

--- a/libs/GraphicECS/SFML/Components/AllowMouseAndKeyboardComponent.hpp
+++ b/libs/GraphicECS/SFML/Components/AllowMouseAndKeyboardComponent.hpp
@@ -10,10 +10,10 @@
 
 #include "Component/Component.hpp"
 
-namespace ecs
+namespace graphicECS::SFML::Components
 {
     /// @brief This component class allows mouse and keyboard usage in client.
     class AllowMouseAndKeyboardComponent : public Component {};
-} // namespace ecs
+} // namespace graphicECS::SFML::Components
 
 #endif /* !ALLOWMOUSEANDKEYBOARDCOMPONENT_HPP_ */

--- a/libs/GraphicECS/SFML/Components/AllowMouseAndKeyboardComponent.hpp
+++ b/libs/GraphicECS/SFML/Components/AllowMouseAndKeyboardComponent.hpp
@@ -13,7 +13,7 @@
 namespace graphicECS::SFML::Components
 {
     /// @brief This component class allows mouse and keyboard usage in client.
-    class AllowMouseAndKeyboardComponent : public Component {};
+    class AllowMouseAndKeyboardComponent : public ecs::Component {};
 } // namespace graphicECS::SFML::Components
 
 #endif /* !ALLOWMOUSEANDKEYBOARDCOMPONENT_HPP_ */

--- a/libs/GraphicECS/SFML/Components/AnimationComponent.hpp
+++ b/libs/GraphicECS/SFML/Components/AnimationComponent.hpp
@@ -15,10 +15,10 @@
 namespace graphicECS::SFML::Components
 {
     /// @brief This component stores a vector of textures to make an animation with them.
-    class AnimationComponent : public Component {
+    class AnimationComponent : public ecs::Component {
       public:
         /// @brief A vector of textureName to store textures used for the animation.
-        std::vector<GraphicsTextureResource::textureName_e> textures;
+        std::vector<ecs::GraphicsTextureResource::textureName_e> textures;
 
         /// @brief Default constructor of AnimationComponent.
         AnimationComponent() = default;

--- a/libs/GraphicECS/SFML/Components/AnimationComponent.hpp
+++ b/libs/GraphicECS/SFML/Components/AnimationComponent.hpp
@@ -12,20 +12,20 @@
 #include "Component/Component.hpp"
 #include "GraphicECS/SFML/Resources/GraphicsTextureResource.hpp"
 
-namespace ecs
+namespace graphicECS::SFML::Components
 {
     /// @brief This component stores a vector of textures to make an animation with them.
     class AnimationComponent : public Component {
-        public:
-            /// @brief A vector of textureName to store textures used for the animation.
-            std::vector<GraphicsTextureResource::textureName_e> textures;
+      public:
+        /// @brief A vector of textureName to store textures used for the animation.
+        std::vector<GraphicsTextureResource::textureName_e> textures;
 
-            /// @brief Default constructor of AnimationComponent.
-            AnimationComponent() = default;
+        /// @brief Default constructor of AnimationComponent.
+        AnimationComponent() = default;
 
-            /// @brief Default destructor of AnimationComponent.
-            ~AnimationComponent() = default;
+        /// @brief Default destructor of AnimationComponent.
+        ~AnimationComponent() = default;
     };
-}
+} // namespace graphicECS::SFML::Components
 
 #endif /* !ANIMATIONCOMPONENT_HPP_ */

--- a/libs/GraphicECS/SFML/Components/ControllerButtonInputComponent.hpp
+++ b/libs/GraphicECS/SFML/Components/ControllerButtonInputComponent.hpp
@@ -18,10 +18,10 @@ namespace graphicECS::SFML::Components
     /// @brief This component class stores an unsorted map of action/value pair.
     /// This class is created in order to find an action depending on a controller button input.
     /// It inherites from Component.
-    class ControllerButtonInputComponent : public Component {
+    class ControllerButtonInputComponent : public ecs::Component {
       public:
         /// @brief This unordered_map links SFML controller button input to an action/value pair enum.
-        std::unordered_map<unsigned int, std::function<void(World &, float)>> controllerButtonMapActions;
+        std::unordered_map<unsigned int, std::function<void(ecs::World &, float)>> controllerButtonMapActions;
 
         /// @brief Default constructor of the class.
         ControllerButtonInputComponent() = default;

--- a/libs/GraphicECS/SFML/Components/ControllerButtonInputComponent.hpp
+++ b/libs/GraphicECS/SFML/Components/ControllerButtonInputComponent.hpp
@@ -8,27 +8,27 @@
 #ifndef CONTROLLERBUTTONINPUTCOMPONENT_HPP_
 #define CONTROLLERBUTTONINPUTCOMPONENT_HPP_
 
-#include <unordered_map>
 #include <functional>
 #include "Component/Component.hpp"
 #include "World/World.hpp"
+#include <unordered_map>
 
-namespace ecs
+namespace graphicECS::SFML::Components
 {
     /// @brief This component class stores an unsorted map of action/value pair.
     /// This class is created in order to find an action depending on a controller button input.
     /// It inherites from Component.
     class ControllerButtonInputComponent : public Component {
-        public:
-            /// @brief This unordered_map links SFML controller button input to an action/value pair enum.
-            std::unordered_map<unsigned int, std::function<void(World &, float)>> controllerButtonMapActions;
+      public:
+        /// @brief This unordered_map links SFML controller button input to an action/value pair enum.
+        std::unordered_map<unsigned int, std::function<void(World &, float)>> controllerButtonMapActions;
 
-            /// @brief Default constructor of the class.
-            ControllerButtonInputComponent() = default;
+        /// @brief Default constructor of the class.
+        ControllerButtonInputComponent() = default;
 
-            /// @brief Default destructor of the class.
-            ~ControllerButtonInputComponent() = default;
+        /// @brief Default destructor of the class.
+        ~ControllerButtonInputComponent() = default;
     };
-} // namespace ecs
+} // namespace graphicECS::SFML::Components
 
 #endif /* !CONTROLLERButtonINPUTCOMPONENT_HPP_ */

--- a/libs/GraphicECS/SFML/Components/ControllerJoystickInputComponent.hpp
+++ b/libs/GraphicECS/SFML/Components/ControllerJoystickInputComponent.hpp
@@ -19,7 +19,7 @@ namespace graphicECS::SFML::Components
     /// @brief This component class stores an unsorted map of action/value pair.
     /// This class is created in order to find an action depending on a controller joystick input.
     /// It inherites from Component.
-    class ControllerJoystickInputComponent : public Component {
+    class ControllerJoystickInputComponent : public ecs::Component {
       public:
         /// @brief This unordered_map links SFML controller joystick input to an action/value pair enum.
         std::unordered_map<unsigned int, std::pair<ActionQueueComponent::inputAction_e, float>>

--- a/libs/GraphicECS/SFML/Components/ControllerJoystickInputComponent.hpp
+++ b/libs/GraphicECS/SFML/Components/ControllerJoystickInputComponent.hpp
@@ -8,13 +8,13 @@
 #ifndef CONTROLLERJOYSTICKINPUTCOMPONENT_HPP_
 #define CONTROLLERJOYSTICKINPUTCOMPONENT_HPP_
 
+#include <functional>
+#include "ActionQueueComponent.hpp"
 #include "Component/Component.hpp"
 #include "World/World.hpp"
-#include "ActionQueueComponent.hpp"
-#include <functional>
 #include <unordered_map>
 
-namespace ecs
+namespace graphicECS::SFML::Components
 {
     /// @brief This component class stores an unsorted map of action/value pair.
     /// This class is created in order to find an action depending on a controller joystick input.
@@ -22,7 +22,8 @@ namespace ecs
     class ControllerJoystickInputComponent : public Component {
       public:
         /// @brief This unordered_map links SFML controller joystick input to an action/value pair enum.
-        std::unordered_map<unsigned int, std::pair<ActionQueueComponent::inputAction_e, float>> controllerJoystickMapActions;
+        std::unordered_map<unsigned int, std::pair<ActionQueueComponent::inputAction_e, float>>
+            controllerJoystickMapActions;
 
         /// @brief Constructor of the class.
         ControllerJoystickInputComponent() = default;
@@ -30,6 +31,6 @@ namespace ecs
         /// @brief Default destructor of the class.
         ~ControllerJoystickInputComponent() = default;
     };
-} // namespace ecs
+} // namespace graphicECS::SFML::Components
 
 #endif /* !CONTROLLERJOYSTICKINPUTCOMPONENT_HPP_ */

--- a/libs/GraphicECS/SFML/Components/ECSActions.hpp
+++ b/libs/GraphicECS/SFML/Components/ECSActions.hpp
@@ -8,12 +8,12 @@
 #ifndef ECSACTION_HPP_
 #define ECSACTION_HPP_
 
-namespace ecs
+namespace graphicECS::SFML::Components
 {
     namespace Actions
     {
         /// Action funtion have to be added. They will be add in issue #93.
     }
-}
+} // namespace graphicECS::SFML::Components
 
 #endif /* !ECSACTION_HPP_ */

--- a/libs/GraphicECS/SFML/Components/GraphicsRectangleComponent.cpp
+++ b/libs/GraphicECS/SFML/Components/GraphicsRectangleComponent.cpp
@@ -7,7 +7,7 @@
 
 #include "GraphicsRectangleComponent.hpp"
 
-using namespace ecs;
+using namespace graphicECS::SFML::Components;
 
 GraphicsRectangleComponent::GraphicsRectangleComponent(
     const std::size_t x, const std::size_t y, const std::size_t width, const std::size_t height)

--- a/libs/GraphicECS/SFML/Components/GraphicsRectangleComponent.hpp
+++ b/libs/GraphicECS/SFML/Components/GraphicsRectangleComponent.hpp
@@ -15,7 +15,7 @@ namespace graphicECS::SFML::Components
 {
     /// @brief This component class stores a Graphical SFML rectangle shape.
     /// This class is created in order to draw a rectangle shape on a screen.
-    class GraphicsRectangleComponent : public Component {
+    class GraphicsRectangleComponent : public ecs::Component {
       public:
         /// @brief The Graphical SFML rectangle shape to be rendered.
         sf::RectangleShape shape;

--- a/libs/GraphicECS/SFML/Components/GraphicsRectangleComponent.hpp
+++ b/libs/GraphicECS/SFML/Components/GraphicsRectangleComponent.hpp
@@ -8,28 +8,29 @@
 #ifndef GRAPHICSRECTANGLECOMPONENT_HPP_
 #define GRAPHICSRECTANGLECOMPONENT_HPP_
 
-#include "Component/Component.hpp"
 #include <SFML/Graphics.hpp>
+#include "Component/Component.hpp"
 
-namespace ecs
+namespace graphicECS::SFML::Components
 {
     /// @brief This component class stores a Graphical SFML rectangle shape.
     /// This class is created in order to draw a rectangle shape on a screen.
     class GraphicsRectangleComponent : public Component {
-        public:
-            /// @brief The Graphical SFML rectangle shape to be rendered.
-            sf::RectangleShape shape;
+      public:
+        /// @brief The Graphical SFML rectangle shape to be rendered.
+        sf::RectangleShape shape;
 
-            /// @brief Construct a GraphicsRectanbleComponent with default parameters if they aren't specified.
-            /// @param x The x position of the shape on the window. Default 10.
-            /// @param y The y position of the shape on the window. Default 10.
-            /// @param width The width size of the shape on the window. Default 10.
-            /// @param height The height size of the shape on the window. Default 10.
-            GraphicsRectangleComponent(const std::size_t x = 10, const std::size_t y = 10, const std::size_t width = 10, const std::size_t height = 10);
+        /// @brief Construct a GraphicsRectanbleComponent with default parameters if they aren't specified.
+        /// @param x The x position of the shape on the window. Default 10.
+        /// @param y The y position of the shape on the window. Default 10.
+        /// @param width The width size of the shape on the window. Default 10.
+        /// @param height The height size of the shape on the window. Default 10.
+        GraphicsRectangleComponent(const std::size_t x = 10, const std::size_t y = 10, const std::size_t width = 10,
+            const std::size_t height = 10);
 
-            /// @brief Default destructor of the class.
-            ~GraphicsRectangleComponent() = default;
+        /// @brief Default destructor of the class.
+        ~GraphicsRectangleComponent() = default;
     };
-} // namespace ecs
+} // namespace graphicECS::SFML::Components
 
 #endif /* !GRAPHICSRECTANGLECOMPONENT_HPP_ */

--- a/libs/GraphicECS/SFML/Components/GraphicsTextComponent.cpp
+++ b/libs/GraphicECS/SFML/Components/GraphicsTextComponent.cpp
@@ -7,9 +7,10 @@
 
 #include "GraphicsTextComponent.hpp"
 
-using namespace ecs;
+using namespace graphicECS::SFML::Components;
 
-GraphicsTextComponent::GraphicsTextComponent(const std::string newText, const std::size_t x, const std::size_t y, const std::size_t size)
+GraphicsTextComponent::GraphicsTextComponent(
+    const std::string newText, const std::size_t x, const std::size_t y, const std::size_t size)
 {
     text.setString(newText);
     text.setPosition(x, y);

--- a/libs/GraphicECS/SFML/Components/GraphicsTextComponent.hpp
+++ b/libs/GraphicECS/SFML/Components/GraphicsTextComponent.hpp
@@ -11,7 +11,7 @@
 #include <SFML/Graphics.hpp>
 #include "Component/Component.hpp"
 
-namespace ecs
+namespace graphicECS::SFML::Components
 {
     /// @brief This component class stores a Graphical SFML text.
     /// This class is created in order to draw a text on a screen, specified in shared resource as a window.
@@ -32,6 +32,6 @@ namespace ecs
         /// @brief Default destructor of the class.
         ~GraphicsTextComponent() = default;
     };
-} // namespace ecs
+} // namespace graphicECS::SFML::Components
 
 #endif /* !GRAPHICSTEXTCOMPONENT_HPP_ */

--- a/libs/GraphicECS/SFML/Components/GraphicsTextComponent.hpp
+++ b/libs/GraphicECS/SFML/Components/GraphicsTextComponent.hpp
@@ -15,7 +15,7 @@ namespace graphicECS::SFML::Components
 {
     /// @brief This component class stores a Graphical SFML text.
     /// This class is created in order to draw a text on a screen, specified in shared resource as a window.
-    class GraphicsTextComponent : public Component {
+    class GraphicsTextComponent : public ecs::Component {
       public:
         /// @brief The Graphical SFML text to be rendered.
         /// @note It needs a font component to be drawn.

--- a/libs/GraphicECS/SFML/Components/KeyboardInputComponent.hpp
+++ b/libs/GraphicECS/SFML/Components/KeyboardInputComponent.hpp
@@ -8,23 +8,24 @@
 #ifndef KEYBOARDINPUTCOMPONENT_HPP_
 #define KEYBOARDINPUTCOMPONENT_HPP_
 
-#include "Component/Component.hpp"
-#include "World/World.hpp"
-#include "ActionQueueComponent.hpp"
 #include <SFML/Graphics.hpp>
 #include <functional>
+#include "ActionQueueComponent.hpp"
+#include "Component/Component.hpp"
+#include "World/World.hpp"
 #include <unordered_map>
 
-namespace ecs
+namespace graphicECS::SFML::Components
 {
     /// @brief This component class stores an unsorted map of action/value pair.
     /// This class is created in order to find an action depending on a key pressed or released.
     /// It inherits from Component.
     class KeyboardInputComponent : public Component {
-        public:
-            /// @brief This unordered_map links SFML key input to an action/value pair enum.
-            std::unordered_map<sf::Keyboard::Key, std::pair<ActionQueueComponent::inputAction_e, float>> keyboardMapActions;
-            // std::unordered_map<sf::Keyboard::Key, std::_Bind<void (ecs::InputManagement::*(ecs::KeyboardInputComponent, std::shared_ptr<ecs::World>, float))(ecs::World &world, float move)>> keyboardMapActions;
+      public:
+        /// @brief This unordered_map links SFML key input to an action/value pair enum.
+        std::unordered_map<sf::Keyboard::Key, std::pair<ActionQueueComponent::inputAction_e, float>> keyboardMapActions;
+        // std::unordered_map<sf::Keyboard::Key, std::_Bind<void (ecs::InputManagement::*(ecs::KeyboardInputComponent,
+        // std::shared_ptr<ecs::World>, float))(ecs::World &world, float move)>> keyboardMapActions;
 
         /// @brief Constructor of the class.
         KeyboardInputComponent() = default;
@@ -32,6 +33,6 @@ namespace ecs
         /// @brief Default destructor of the class.
         ~KeyboardInputComponent() = default;
     };
-} // namespace ecs
+} // namespace graphicECS::SFML::Components
 
 #endif /* !KEYBOARDINPUTCOMPONENT_HPP_ */

--- a/libs/GraphicECS/SFML/Components/KeyboardInputComponent.hpp
+++ b/libs/GraphicECS/SFML/Components/KeyboardInputComponent.hpp
@@ -20,7 +20,7 @@ namespace graphicECS::SFML::Components
     /// @brief This component class stores an unsorted map of action/value pair.
     /// This class is created in order to find an action depending on a key pressed or released.
     /// It inherits from Component.
-    class KeyboardInputComponent : public Component {
+    class KeyboardInputComponent : public ecs::Component {
       public:
         /// @brief This unordered_map links SFML key input to an action/value pair enum.
         std::unordered_map<sf::Keyboard::Key, std::pair<ActionQueueComponent::inputAction_e, float>> keyboardMapActions;

--- a/libs/GraphicECS/SFML/Components/MouseInputComponent.hpp
+++ b/libs/GraphicECS/SFML/Components/MouseInputComponent.hpp
@@ -8,22 +8,21 @@
 #ifndef MOUSEINPUTCOMPONENT_HPP_
 #define MOUSEINPUTCOMPONENT_HPP_
 
-#include "Component/Component.hpp"
-#include "World/World.hpp"
 #include <SFML/Graphics.hpp>
 #include <functional>
 #include "Component/Component.hpp"
+#include "World/World.hpp"
 #include <unordered_map>
 
-namespace ecs
+namespace graphicECS::SFML::Components
 {
     /// @brief This component class stores an unsorted map of action/value pair.
     /// This class is created in order to find an action depending on a mouse button pressed or released.
     /// It inherits from Component.
     class MouseInputComponent : public Component {
-        public:
-            /// @brief This unordered map links SFML mouse button input to an action/float pair enum.
-            std::unordered_map<sf::Mouse::Button, std::pair<ActionQueueComponent::inputAction_e, float>> MouseMapActions;
+      public:
+        /// @brief This unordered map links SFML mouse button input to an action/float pair enum.
+        std::unordered_map<sf::Mouse::Button, std::pair<ActionQueueComponent::inputAction_e, float>> MouseMapActions;
 
         /// @brief Constructor of the class.
         MouseInputComponent() = default;
@@ -31,6 +30,6 @@ namespace ecs
         /// @brief Default destructor of the class.
         ~MouseInputComponent() = default;
     };
-} // namespace ecs
+} // namespace graphicECS::SFML::Components
 
 #endif /* !MOUSEINPUTCOMPONENT_HPP_ */

--- a/libs/GraphicECS/SFML/Components/MouseInputComponent.hpp
+++ b/libs/GraphicECS/SFML/Components/MouseInputComponent.hpp
@@ -19,7 +19,7 @@ namespace graphicECS::SFML::Components
     /// @brief This component class stores an unsorted map of action/value pair.
     /// This class is created in order to find an action depending on a mouse button pressed or released.
     /// It inherits from Component.
-    class MouseInputComponent : public Component {
+    class MouseInputComponent : public ecs::Component {
       public:
         /// @brief This unordered map links SFML mouse button input to an action/float pair enum.
         std::unordered_map<sf::Mouse::Button, std::pair<ActionQueueComponent::inputAction_e, float>> MouseMapActions;

--- a/libs/GraphicECS/SFML/Components/ParallaxComponent.hpp
+++ b/libs/GraphicECS/SFML/Components/ParallaxComponent.hpp
@@ -10,10 +10,10 @@
 
 #include "Component/Component.hpp"
 
-namespace ecs
+namespace graphicECS::SFML::Components
 {
     /// @brief This component class create a sprite wich travel in the background
     class ParallaxBackground : public Component {};
-} // namespace ecs
+} // namespace graphicECS::SFML::Components
 
 #endif /* !PARALLAXCOMPONENT_HPP_ */

--- a/libs/GraphicECS/SFML/Components/ParallaxComponent.hpp
+++ b/libs/GraphicECS/SFML/Components/ParallaxComponent.hpp
@@ -13,7 +13,7 @@
 namespace graphicECS::SFML::Components
 {
     /// @brief This component class create a sprite wich travel in the background
-    class ParallaxBackground : public Component {};
+    class ParallaxBackground : public ecs::Component {};
 } // namespace graphicECS::SFML::Components
 
 #endif /* !PARALLAXCOMPONENT_HPP_ */

--- a/libs/GraphicECS/SFML/Components/TextureName.hpp
+++ b/libs/GraphicECS/SFML/Components/TextureName.hpp
@@ -14,7 +14,7 @@
 namespace graphicECS::SFML::Components
 {
     /// @brief TextureName store the key as enum to the corresponding texture stores in shared resource.
-    class TextureName : public Component {
+    class TextureName : public ecs::Component {
       public:
         /// @brief The texture name stores to find the corresponding textureName.
         GraphicsTextureResource::textureName_e textureName;
@@ -22,7 +22,7 @@ namespace graphicECS::SFML::Components
         /// @brief Constructor of the TextureName component
         /// @param newTextureName The value to set in the textureName, corresponding
         /// on the sf::Texture load in shared resource GraphicsTexture.
-        TextureName(GraphicsTextureResource::textureName_e newTextureName = GraphicsTextureResource::UNDEFINED)
+        TextureName(ecs::GraphicsTextureResource::textureName_e newTextureName = ecs::GraphicsTextureResource::UNDEFINED)
             : textureName(newTextureName){};
 
         /// @brief Default destructor of TextureName component.

--- a/libs/GraphicECS/SFML/Components/TextureName.hpp
+++ b/libs/GraphicECS/SFML/Components/TextureName.hpp
@@ -11,7 +11,7 @@
 #include "Component/Component.hpp"
 #include "GraphicECS/SFML/Resources/GraphicsTextureResource.hpp"
 
-namespace ecs
+namespace graphicECS::SFML::Components
 {
     /// @brief TextureName store the key as enum to the corresponding texture stores in shared resource.
     class TextureName : public Component {
@@ -28,6 +28,6 @@ namespace ecs
         /// @brief Default destructor of TextureName component.
         ~TextureName() = default;
     };
-} // namespace ecs
+} // namespace graphicECS::SFML::Components
 
 #endif /* !TEXTURENAME_HPP_ */

--- a/libs/GraphicECS/SFML/Systems/DrawComponents.cpp
+++ b/libs/GraphicECS/SFML/Systems/DrawComponents.cpp
@@ -19,6 +19,7 @@
 #include "R-TypeLogic/Global/Components/SizeComponent.hpp"
 
 using namespace ecs;
+using namespace graphicECS::SFML::Components;
 
 bool DrawComponents::compareLayer(std::shared_ptr<Entity> e1, std::shared_ptr<Entity> e2)
 {

--- a/libs/GraphicECS/SFML/Systems/InputManagement.cpp
+++ b/libs/GraphicECS/SFML/Systems/InputManagement.cpp
@@ -24,6 +24,8 @@
 #include "R-TypeLogic/EntityManipulation/ButtonManipulation/SharedResources/ButtonActionMap.hpp"
 #include "R-TypeLogic/Global/SharedResources/GameClock.hpp"
 
+using namespace graphicECS::SFML::Components;
+
 namespace ecs
 {
     void InputManagement::_closeWindow(sf::Event &event, World &world)
@@ -93,7 +95,7 @@ namespace ecs
             _mouseEvents(event, Inputs);
         }
         for (auto &entityPtr : Inputs) {
-            std::queue<std::pair<ecs::ActionQueueComponent::inputAction_e, float>> &actions =
+            std::queue<std::pair<ActionQueueComponent::inputAction_e, float>> &actions =
                 entityPtr->getComponent<ActionQueueComponent>().actions;
             while (actions.size() > 0) {
                 if (actions.front().first == ActionQueueComponent::MOVEY)

--- a/libs/GraphicECS/SFML/Systems/ParallaxSystem.cpp
+++ b/libs/GraphicECS/SFML/Systems/ParallaxSystem.cpp
@@ -11,6 +11,8 @@
 
 #define MAXIMUM_WIDTH 1920
 
+using namespace graphicECS::SFML::Components;
+
 void Parallax::run(World &world)
 {
     std::vector<std::shared_ptr<ecs::Entity>> joined = world.joinEntities<ParallaxBackground>();

--- a/libs/GraphicECS/SFML/Systems/SfRectangleFollowEntitySystem.cpp
+++ b/libs/GraphicECS/SFML/Systems/SfRectangleFollowEntitySystem.cpp
@@ -7,6 +7,8 @@
 
 #include "SfRectangleFollowEntitySystem.hpp"
 
+using namespace graphicECS::SFML::Components;
+
 void SfRectangleFollowEntitySystem::run(World &world)
 {
     std::vector<std::shared_ptr<Entity>> entities = world.joinEntities<GraphicsRectangleComponent, Position>();

--- a/tests/unit_tests/libs_tests/SFML_tests/AllowControllerComponentTests.cpp
+++ b/tests/unit_tests/libs_tests/SFML_tests/AllowControllerComponentTests.cpp
@@ -9,6 +9,7 @@
 #include "AllowControllerComponent.hpp"
 
 using namespace ecs;
+using namespace graphicECS::SFML::Components;
 
 Test(AllowControllerComponent, test_class_constructor)
 {

--- a/tests/unit_tests/libs_tests/SFML_tests/AllowMouseAndKeyboardComponentTests.cpp
+++ b/tests/unit_tests/libs_tests/SFML_tests/AllowMouseAndKeyboardComponentTests.cpp
@@ -9,6 +9,7 @@
 #include "AllowMouseAndKeyboardComponent.hpp"
 
 using namespace ecs;
+using namespace graphicECS::SFML::Components;
 
 Test(AllowMouseAndKeyboardComponent, test_class_constructor)
 {

--- a/tests/unit_tests/libs_tests/SFML_tests/Components/AnimationComponent_tests.cpp
+++ b/tests/unit_tests/libs_tests/SFML_tests/Components/AnimationComponent_tests.cpp
@@ -8,9 +8,11 @@
 #include <criterion/criterion.h>
 #include "AnimationComponent.hpp"
 
+using namespace graphicECS::SFML::Components;
+
 Test(AnimationComponent, create_class)
 {
-    ecs::AnimationComponent a;
+    AnimationComponent a;
 
     cr_assert_eq(1, 1);
 }

--- a/tests/unit_tests/libs_tests/SFML_tests/GraphicsRectangleComponentTests.cpp
+++ b/tests/unit_tests/libs_tests/SFML_tests/GraphicsRectangleComponentTests.cpp
@@ -9,6 +9,7 @@
 #include "GraphicsRectangleComponent.hpp"
 
 using namespace ecs;
+using namespace graphicECS::SFML::Components;
 
 Test(GraphicsRectangleComponent, test_create_class)
 {

--- a/tests/unit_tests/libs_tests/SFML_tests/GraphicsTextComponentTests.cpp
+++ b/tests/unit_tests/libs_tests/SFML_tests/GraphicsTextComponentTests.cpp
@@ -9,6 +9,7 @@
 #include <GraphicsTextComponent.hpp>
 
 using namespace ecs;
+using namespace graphicECS::SFML::Components;
 
 Test(GraphicsTextComponent, test_create_function)
 {

--- a/tests/unit_tests/libs_tests/SFML_tests/Input_functions_tests.cpp
+++ b/tests/unit_tests/libs_tests/SFML_tests/Input_functions_tests.cpp
@@ -18,6 +18,7 @@
 #include "R-TypeLogic/Global/Systems/MovementSystem.hpp"
 
 using namespace ecs;
+using namespace graphicECS::SFML::Components;
 
 Test(movePlayerX, Move_x_of_a_player)
 {

--- a/tests/unit_tests/libs_tests/SFML_tests/Systems/InputManagement_tests.cpp
+++ b/tests/unit_tests/libs_tests/SFML_tests/Systems/InputManagement_tests.cpp
@@ -18,6 +18,8 @@
 #define private public
 #include "InputManagement.hpp"
 
+using namespace graphicECS::SFML::Components;
+
 Test(InputManagement, create_system)
 {
     InputManagement inputs;


### PR DESCRIPTION
## Updated features
- Move SFML component to namespace `graphicECS::SFML::Components`

## Fixed features
- Use `using namespace graphicECS::SFML::Components` when needed