### PR TITLE
246 fix sfml resources namespace

### DIFF
--- a/Client/ButtonAction.cpp
+++ b/Client/ButtonAction.cpp
@@ -8,6 +8,8 @@
 #include "ButtonAction.hpp"
 #include "GraphicECS/SFML/Resources/RenderWindowResource.hpp"
 
+using namespace graphicECS::SFML::Resources;
+
 void exitWindow(World &world)
 {
     // TO CHANGE WHEN PROPER HANDLE OF SIGINT WILL BE IMPLEMENTED

--- a/libs/GraphicECS/SFML/Components/TextureName.hpp
+++ b/libs/GraphicECS/SFML/Components/TextureName.hpp
@@ -11,6 +11,8 @@
 #include "Component/Component.hpp"
 #include "GraphicECS/SFML/Resources/GraphicsTextureResource.hpp"
 
+using namespace graphicECS::SFML::Resources;
+
 namespace ecs
 {
     /// @brief TextureName store the key as enum to the corresponding texture stores in shared resource.

--- a/libs/GraphicECS/SFML/Resources/GraphicsFontResource.hpp
+++ b/libs/GraphicECS/SFML/Resources/GraphicsFontResource.hpp
@@ -12,7 +12,7 @@
 #include <filesystem>
 #include "Resource/Resource.hpp"
 
-namespace ecs
+namespace graphicECS::SFML::Resources
 {
     /// @brief This resource class stores the font in order to draw a Graphical text resource.
     /// It justs exist for the Graphical text resource.
@@ -32,6 +32,6 @@ namespace ecs
         /// @brief Default destructor of the class.
         ~GraphicsFontResource() = default;
     };
-} // namespace ecs
+} // namespace graphicECS::SFML::Resources
 
 #endif /* !GRAPHICSFONTRESOURCE_HPP_ */

--- a/libs/GraphicECS/SFML/Resources/GraphicsFontResource.hpp
+++ b/libs/GraphicECS/SFML/Resources/GraphicsFontResource.hpp
@@ -16,7 +16,7 @@ namespace graphicECS::SFML::Resources
 {
     /// @brief This resource class stores the font in order to draw a Graphical text resource.
     /// It justs exist for the Graphical text resource.
-    class GraphicsFontResource : public Resource {
+    class GraphicsFontResource : public ecs::Resource {
       public:
         /// @brief The Graphical SFML font to be used with Graphical text resource.
         /// @note Only used with Graphical text resource.

--- a/libs/GraphicECS/SFML/Resources/GraphicsTextureResource.cpp
+++ b/libs/GraphicECS/SFML/Resources/GraphicsTextureResource.cpp
@@ -7,7 +7,7 @@
 
 #include "GraphicsTextureResource.hpp"
 
-using namespace ecs;
+using namespace graphicECS::SFML::Resources;
 
 void GraphicsTextureResource::addTexture(const textureName_e texture_e, const std::filesystem::path &texturePath,
     const sf::Vector2f &position, const sf::Vector2f &size)

--- a/libs/GraphicECS/SFML/Resources/GraphicsTextureResource.hpp
+++ b/libs/GraphicECS/SFML/Resources/GraphicsTextureResource.hpp
@@ -13,7 +13,7 @@
 #include "Resource/Resource.hpp"
 #include <unordered_map>
 
-namespace ecs
+namespace graphicECS::SFML::Resources
 {
 
     /// @brief This resource class stores a map of Graphical SFML textures to be set on Shapes.
@@ -65,6 +65,6 @@ namespace ecs
 
         TexturesList _texturesList;
     };
-} // namespace ecs
+} // namespace graphicECS::SFML::Resources
 
 #endif /* !GRAPHICSTEXTURERESOURCE_HPP_ */

--- a/libs/GraphicECS/SFML/Resources/GraphicsTextureResource.hpp
+++ b/libs/GraphicECS/SFML/Resources/GraphicsTextureResource.hpp
@@ -17,7 +17,7 @@ namespace graphicECS::SFML::Resources
 {
 
     /// @brief This resource class stores a map of Graphical SFML textures to be set on Shapes.
-    class GraphicsTextureResource : public Resource {
+    class GraphicsTextureResource : public ecs::Resource {
       public:
         /// @brief Enumeration of all available Textures
         enum textureName_e {

--- a/libs/GraphicECS/SFML/Resources/RenderWindowResource.hpp
+++ b/libs/GraphicECS/SFML/Resources/RenderWindowResource.hpp
@@ -17,7 +17,7 @@ namespace graphicECS::SFML::Resources
     /// @brief This shared resource adds a window.
     /// It will used by graphics part to draw something on screen, and get inputs on client part.
     /// It inherite from Resource class.
-    class RenderWindowResource : public Resource {
+    class RenderWindowResource : public ecs::Resource {
       public:
         /// @brief Constructor of the render window resource class.
         /// @param title The title of the window as string. Set to "Default" as default.

--- a/libs/GraphicECS/SFML/Resources/RenderWindowResource.hpp
+++ b/libs/GraphicECS/SFML/Resources/RenderWindowResource.hpp
@@ -12,7 +12,7 @@
 #include <string>
 #include "Resource/Resource.hpp"
 
-namespace ecs
+namespace graphicECS::SFML::Resources
 {
     /// @brief This shared resource adds a window.
     /// It will used by graphics part to draw something on screen, and get inputs on client part.
@@ -38,6 +38,6 @@ namespace ecs
         /// @brief The window to draw on or get inputs from it.
         sf::RenderWindow window;
     };
-} // namespace ecs
+} // namespace graphicECS::SFML::Resources
 
 #endif /* !RENDERWINDOWRESOURCE_HPP_ */

--- a/libs/GraphicECS/SFML/Systems/DrawComponents.cpp
+++ b/libs/GraphicECS/SFML/Systems/DrawComponents.cpp
@@ -19,6 +19,7 @@
 #include "R-TypeLogic/Global/Components/SizeComponent.hpp"
 
 using namespace ecs;
+using namespace graphicECS::SFML::Resources;
 
 bool DrawComponents::compareLayer(std::shared_ptr<Entity> e1, std::shared_ptr<Entity> e2)
 {

--- a/libs/GraphicECS/SFML/Systems/InputManagement.cpp
+++ b/libs/GraphicECS/SFML/Systems/InputManagement.cpp
@@ -24,6 +24,8 @@
 #include "R-TypeLogic/EntityManipulation/ButtonManipulation/SharedResources/ButtonActionMap.hpp"
 #include "R-TypeLogic/Global/SharedResources/GameClock.hpp"
 
+using namespace graphicECS::SFML::Resources;
+
 namespace ecs
 {
     void InputManagement::_closeWindow(sf::Event &event, World &world)


### PR DESCRIPTION
## Updated features
- Create namespace `graphicECS::SFML::Resources` instead of using `ecs` namespace in SFML Resource part.