### PR TITLE
248 fix sfml systems namespace

### DIFF
--- a/Client/ClientRoom.cpp
+++ b/Client/ClientRoom.cpp
@@ -48,6 +48,7 @@ using namespace error_lib;
 using namespace communicator_lib;
 using namespace client_data;
 using namespace ecs;
+using namespace graphicECS::SFML::Systems;
 
 static ClientRoom::ClientState *clientRoomState(nullptr);
 

--- a/libs/GraphicECS/SFML/Systems/DrawComponents.cpp
+++ b/libs/GraphicECS/SFML/Systems/DrawComponents.cpp
@@ -18,7 +18,7 @@
 #include "R-TypeLogic/Global/Components/PositionComponent.hpp"
 #include "R-TypeLogic/Global/Components/SizeComponent.hpp"
 
-using namespace ecs;
+using namespace graphicECS::SFML::Systems;
 
 bool DrawComponents::compareLayer(std::shared_ptr<Entity> e1, std::shared_ptr<Entity> e2)
 {

--- a/libs/GraphicECS/SFML/Systems/DrawComponents.hpp
+++ b/libs/GraphicECS/SFML/Systems/DrawComponents.hpp
@@ -11,7 +11,7 @@
 #include "System/System.hpp"
 #include "World/World.hpp"
 
-namespace ecs
+namespace graphicECS::SFML::Systems
 {
     /// @brief This class draw GraphicsComponents on window.
     struct DrawComponents : public System {
@@ -25,6 +25,6 @@ namespace ecs
         /// @param world The corresponding world on which run this system.
         void run(World &world) override final;
     };
-} // namespace ecs
+} // namespace graphicECS::SFML::Systems
 
 #endif /* !DRAWCOMPONENTS_HPP_ */

--- a/libs/GraphicECS/SFML/Systems/InputManagement.cpp
+++ b/libs/GraphicECS/SFML/Systems/InputManagement.cpp
@@ -19,12 +19,12 @@
 #include "MouseInputComponent.hpp"
 #include "World/World.hpp"
 #include "R-TypeLogic/EntityManipulation/ButtonManipulation/Components/ActionName.hpp"
+#include "R-TypeLogic/EntityManipulation/ButtonManipulation/SharedResources/ButtonActionMap.hpp"
 #include "R-TypeLogic/Global/Components/ButtonComponent.hpp"
 #include "R-TypeLogic/Global/Components/ShootingFrequencyComponent.hpp"
-#include "R-TypeLogic/EntityManipulation/ButtonManipulation/SharedResources/ButtonActionMap.hpp"
 #include "R-TypeLogic/Global/SharedResources/GameClock.hpp"
 
-namespace ecs
+namespace graphicECS::SFML::Systems
 {
     void InputManagement::_closeWindow(sf::Event &event, World &world)
     {
@@ -192,4 +192,4 @@ namespace ecs
         };
         std::for_each(joined.begin(), joined.end(), clickInButton);
     }
-} // namespace ecs
+} // namespace graphicECS::SFML::Systems

--- a/libs/GraphicECS/SFML/Systems/InputManagement.hpp
+++ b/libs/GraphicECS/SFML/Systems/InputManagement.hpp
@@ -15,7 +15,7 @@
 #include "R-TypeLogic/Global/Components/ControlableComponent.hpp"
 #include "R-TypeLogic/Global/Components/VelocityComponent.hpp"
 
-namespace ecs
+namespace graphicECS::SFML::Systems
 {
     /// @brief This system class manage SFML input to link them to an action.
     struct InputManagement : public System {
@@ -72,6 +72,6 @@ namespace ecs
         /// @param Inputs Entity which contains inputs entity like mouse, keyboard and controller
         void _mouseEvents(sf::Event &event, std::vector<std::shared_ptr<Entity>> &Inputs);
     };
-} // namespace ecs
+} // namespace graphicECS::SFML::Systems
 
 #endif /* !INPUTMANAGEMENT_HPP_ */

--- a/libs/GraphicECS/SFML/Systems/ParallaxSystem.cpp
+++ b/libs/GraphicECS/SFML/Systems/ParallaxSystem.cpp
@@ -11,6 +11,8 @@
 
 #define MAXIMUM_WIDTH 1920
 
+using namespace graphicECS::SFML::Systems;
+
 void Parallax::run(World &world)
 {
     std::vector<std::shared_ptr<ecs::Entity>> joined = world.joinEntities<ParallaxBackground>();

--- a/libs/GraphicECS/SFML/Systems/ParallaxSystem.hpp
+++ b/libs/GraphicECS/SFML/Systems/ParallaxSystem.hpp
@@ -11,7 +11,7 @@
 #include "System/System.hpp"
 #include "World/World.hpp"
 
-namespace ecs
+namespace graphicECS::SFML::Systems
 {
     /// @brief Parallax System. Make a moving background to make an "infinite map"
     struct Parallax : public System {
@@ -21,6 +21,6 @@ namespace ecs
         void run(World &world) override final;
     };
 
-} // namespace ecs
+} // namespace graphicECS::SFML::Systems
 
 #endif /* !PARALLAXSYSTEM_HPP_ */

--- a/libs/GraphicECS/SFML/Systems/SfRectangleFollowEntitySystem.cpp
+++ b/libs/GraphicECS/SFML/Systems/SfRectangleFollowEntitySystem.cpp
@@ -7,6 +7,8 @@
 
 #include "SfRectangleFollowEntitySystem.hpp"
 
+using namespace graphicECS::SFML::Systems;
+
 void SfRectangleFollowEntitySystem::run(World &world)
 {
     std::vector<std::shared_ptr<Entity>> entities = world.joinEntities<GraphicsRectangleComponent, Position>();

--- a/libs/GraphicECS/SFML/Systems/SfRectangleFollowEntitySystem.hpp
+++ b/libs/GraphicECS/SFML/Systems/SfRectangleFollowEntitySystem.hpp
@@ -15,7 +15,7 @@
 #include "World/World.hpp"
 #include "R-TypeLogic/Global/Components/PositionComponent.hpp"
 
-namespace ecs
+namespace graphicECS::SFML::Systems
 {
     /// @brief This system class manage SFML Rectangle Shape to modify it's SfRectangleSahpePosition with the Position
     /// of the Entity
@@ -24,6 +24,6 @@ namespace ecs
         /// @param world The corresponding world on which run this system.
         void run(World &world) override final;
     };
-} // namespace ecs
+} // namespace graphicECS::SFML::Systems
 
 #endif /* !SFRECTANGLEFOLLOWENTITYSYSTEM_HPP_ */

--- a/tests/unit_tests/libs_tests/SFML_tests/Input_functions_tests.cpp
+++ b/tests/unit_tests/libs_tests/SFML_tests/Input_functions_tests.cpp
@@ -18,6 +18,7 @@
 #include "R-TypeLogic/Global/Systems/MovementSystem.hpp"
 
 using namespace ecs;
+using namespace graphicECS::SFML::Systems;
 
 Test(movePlayerX, Move_x_of_a_player)
 {

--- a/tests/unit_tests/libs_tests/SFML_tests/Systems/InputManagement_tests.cpp
+++ b/tests/unit_tests/libs_tests/SFML_tests/Systems/InputManagement_tests.cpp
@@ -18,6 +18,8 @@
 #define private public
 #include "InputManagement.hpp"
 
+using namespace graphicECS::SFML::Systems;
+
 Test(InputManagement, create_system)
 {
     InputManagement inputs;


### PR DESCRIPTION
## Updated features
- Move SFML Systems in namespace `graphicECS::SFML::Systems` instead of using `ecs`.