### PR TITLE
Fix ecs::World::containsSystem function

### DIFF
--- a/libs/ECS/World/World.hpp
+++ b/libs/ECS/World/World.hpp
@@ -161,7 +161,7 @@ namespace ecs
         /// @return True if the group of System types is contained in the World. Otherwise False
         template <std::derived_from<System> S1, std::derived_from<System>... S2> bool containsSystem() const
         {
-            if (_resourcesList.count(typeid(S1)) == 0)
+            if (_systemsList.count(typeid(S1)) == 0)
                 return false;
             return containsSystem<S2...>();
         }


### PR DESCRIPTION
## Purpose:
The ecs::World::containsSystem() function checks whether a world contains a system, but actually checks it in the resource list, not in the system list.

## Fix
- The function ecs::World::containsSystem now checks in the list of systems.

This will close #250 