### PR TITLE
Lock the shared resources when they are used

### DIFF
--- a/Client/ButtonAction.cpp
+++ b/Client/ButtonAction.cpp
@@ -7,11 +7,14 @@
 
 #include "ButtonAction.hpp"
 #include "GraphicECS/SFML/Resources/RenderWindowResource.hpp"
+#include <boost/asio/thread_pool.hpp>
 
 using namespace graphicECS::SFML::Resources;
 
 void exitWindow(World &world)
 {
     // TO CHANGE WHEN PROPER HANDLE OF SIGINT WILL BE IMPLEMENTED
-    world.getResource<RenderWindowResource>().window.close();
+    auto &resource = world.getResource<RenderWindowResource>();
+    auto guard = std::lock_guard(resource);
+    resource.window.close();
 }

--- a/Client/ButtonAction.cpp
+++ b/Client/ButtonAction.cpp
@@ -6,8 +6,8 @@
 */
 
 #include "ButtonAction.hpp"
+#include <mutex>
 #include "GraphicECS/SFML/Resources/RenderWindowResource.hpp"
-#include <boost/asio/thread_pool.hpp>
 
 using namespace graphicECS::SFML::Resources;
 

--- a/Client/ButtonAction.cpp
+++ b/Client/ButtonAction.cpp
@@ -14,7 +14,8 @@ using namespace graphicECS::SFML::Resources;
 void exitWindow(World &world)
 {
     // TO CHANGE WHEN PROPER HANDLE OF SIGINT WILL BE IMPLEMENTED
-    auto &resource = world.getResource<RenderWindowResource>();
-    auto guard = std::lock_guard(resource);
+    // At this moment, we can't lock the resource here because we can't close the window
+    // This will be fixed when the above change will be implemented
+    RenderWindowResource &resource = world.getResource<RenderWindowResource>();
     resource.window.close();
 }

--- a/Client/ClientRoom.cpp
+++ b/Client/ClientRoom.cpp
@@ -43,6 +43,7 @@
 #include "R-TypeLogic/Global/Systems/DeathSystem.hpp"
 #include "R-TypeLogic/Global/Systems/MovementSystem.hpp"
 #include "R-TypeLogic/Global/Systems/UpdateClockSystem.hpp"
+#include <boost/asio/thread_pool.hpp>
 
 using namespace error_lib;
 using namespace communicator_lib;
@@ -105,8 +106,10 @@ void ClientRoom::protocol12Answer(CommunicatorMessage connexionResponse)
 {
     _state = ClientState::IN_GAME;
     _worldInstance.get()->addEntity().addComponent<NetworkServer>(connexionResponse.message.clientInfo.getId());
-    _worldInstance.get()->getResource<GameClock>().resetClock();
-    _worldInstance.get()->getResource<GameClock>().resetClock();
+    auto &clock = _worldInstance.get()->getResource<GameClock>();
+    auto guard = std::lock_guard(clock);
+    clock.resetClock();
+    clock.resetClock();
 }
 
 void ClientRoom::startLobbyLoop(void)
@@ -149,6 +152,7 @@ void ClientRoom::_initSpritesForEntities()
     _worldInstance->addResource<GraphicsTextureResource>(GraphicsTextureResource::ENEMY_STATIC,
         "assets/EpiSprite/BasicEnemySpriteSheet.gif", sf::Vector2f(0, 0), sf::Vector2f(34, 34));
     GraphicsTextureResource &spritesList = _worldInstance->getResource<GraphicsTextureResource>();
+    auto guard = std::lock_guard(spritesList);
 
     spritesList.addTexture(GraphicsTextureResource::PLAYER_STATIC, "assets/EpiSprite/BasicPlayerSpriteSheet.gif",
         sf::Vector2f(500, 0), sf::Vector2f(500, 34));

--- a/Client/ClientRoom.cpp
+++ b/Client/ClientRoom.cpp
@@ -10,6 +10,7 @@
 #include "ClientRoom.hpp"
 #include <csignal>
 #include <functional>
+#include <mutex>
 #include "ButtonAction.hpp"
 #include "Error/Error.hpp"
 #include "GraphicECS/SFML/Components/ActionQueueComponent.hpp"
@@ -43,7 +44,6 @@
 #include "R-TypeLogic/Global/Systems/DeathSystem.hpp"
 #include "R-TypeLogic/Global/Systems/MovementSystem.hpp"
 #include "R-TypeLogic/Global/Systems/UpdateClockSystem.hpp"
-#include <boost/asio/thread_pool.hpp>
 
 using namespace error_lib;
 using namespace communicator_lib;

--- a/libs/ECS/Resource/Resource.hpp
+++ b/libs/ECS/Resource/Resource.hpp
@@ -13,7 +13,9 @@ namespace ecs
 {
     /// @brief This is the Resource Class for ECS
     /// The base Resource type, all Resources must inherit from Resource.
-    /// The std::mutex inheritance is in order to allow to lock a Resource when something wants to use/modify it
+    /// The std::mutex inheritance is in order to allow to lock a Resource when something wants to use/modify it.
+    /// \/!\ When you want tu use/modify one already created Resource, you have to lock it. It is recommended to use
+    /// std::lock_guard from boost.
     class Resource : public std::mutex {
       public:
         /// @brief This is the default destructor of Resource Class

--- a/libs/GraphicECS/SFML/Systems/DrawComponents.cpp
+++ b/libs/GraphicECS/SFML/Systems/DrawComponents.cpp
@@ -17,6 +17,7 @@
 #include "R-TypeLogic/Global/Components/LayerLvL.hpp"
 #include "R-TypeLogic/Global/Components/PositionComponent.hpp"
 #include "R-TypeLogic/Global/Components/SizeComponent.hpp"
+#include <boost/asio/thread_pool.hpp>
 
 using namespace graphicECS::SFML::Systems;
 using namespace graphicECS::SFML::Resources;
@@ -30,33 +31,32 @@ bool DrawComponents::compareLayer(std::shared_ptr<Entity> e1, std::shared_ptr<En
 void DrawComponents::run(World &world)
 {
     std::vector<std::shared_ptr<Entity>> Inputs = world.joinEntities<LayerLvL>();
-
-    if (world.getResource<RenderWindowResource>().window.isOpen()) {
-        world.getResource<RenderWindowResource>().window.clear(sf::Color(0x151123));
+    RenderWindowResource &windowResource = world.getResource<RenderWindowResource>();
+    auto guard = std::lock_guard(windowResource);
+    if (windowResource.window.isOpen()) {
+        windowResource.window.clear(sf::Color(0x151123));
         std::sort(Inputs.begin(), Inputs.end(), compareLayer);
-        auto layer = [&world](std::shared_ptr<Entity> entityPtr) {
+        auto layer = [&world, &windowResource](std::shared_ptr<Entity> entityPtr) {
             if (entityPtr->contains<GraphicsRectangleComponent>()) {
                 if (world.containsResource<GraphicsTextureResource>()) {
+                    GraphicsTextureResource &textureResource = world.getResource<GraphicsTextureResource>();
+                    auto guard = std::lock_guard(textureResource);
                     entityPtr->getComponent<GraphicsRectangleComponent>().shape.setTexture(
-                        world.getResource<GraphicsTextureResource>()
-                            ._texturesList[entityPtr->getComponent<TextureName>().textureName]
-                            .get());
+                        textureResource._texturesList[entityPtr->getComponent<TextureName>().textureName].get());
                 } else {
                     entityPtr->getComponent<GraphicsRectangleComponent>().shape.setFillColor(sf::Color::White);
                 }
-                world.getResource<RenderWindowResource>().window.draw(
-                    entityPtr->getComponent<GraphicsRectangleComponent>().shape);
+                windowResource.window.draw(entityPtr->getComponent<GraphicsRectangleComponent>().shape);
                 return;
             }
             if (entityPtr->contains<GraphicsTextComponent>()) {
-                world.getResource<RenderWindowResource>().window.draw(
-                    entityPtr->getComponent<GraphicsTextComponent>().text);
+                windowResource.window.draw(entityPtr->getComponent<GraphicsTextComponent>().text);
                 return;
             }
             auto layerType = entityPtr->getComponent<LayerLvL>();
             if (layerType.layer == LayerLvL::layer_e::OBSTACLE || layerType.layer == LayerLvL::layer_e::ENEMY
-                || layerType.layer == LayerLvL::layer_e::PLAYER || layerType.layer == LayerLvL::layer_e::PROJECTILE ||
-                layerType.layer == LayerLvL::EXIT_BUTTON) {
+                || layerType.layer == LayerLvL::layer_e::PLAYER || layerType.layer == LayerLvL::layer_e::PROJECTILE
+                || layerType.layer == LayerLvL::EXIT_BUTTON) {
                 auto entityPos = entityPtr->getComponent<Position>();
                 auto entitySize = entityPtr->getComponent<Size>();
 
@@ -79,6 +79,6 @@ void DrawComponents::run(World &world)
             }
         };
         std::for_each(Inputs.begin(), Inputs.end(), layer);
-        world.getResource<RenderWindowResource>().window.display();
+        windowResource.window.display();
     }
 }

--- a/libs/GraphicECS/SFML/Systems/DrawComponents.cpp
+++ b/libs/GraphicECS/SFML/Systems/DrawComponents.cpp
@@ -7,6 +7,7 @@
 
 #include "DrawComponents.hpp"
 #include <algorithm>
+#include <mutex>
 #include "GraphicECS/SFML/Resources/RenderWindowResource.hpp"
 #include "GraphicsRectangleComponent.hpp"
 #include "GraphicsTextComponent.hpp"
@@ -17,8 +18,6 @@
 #include "R-TypeLogic/Global/Components/LayerLvL.hpp"
 #include "R-TypeLogic/Global/Components/PositionComponent.hpp"
 #include "R-TypeLogic/Global/Components/SizeComponent.hpp"
-#include <boost/asio/thread_pool.hpp>
-
 using namespace graphicECS::SFML::Systems;
 using namespace graphicECS::SFML::Resources;
 using namespace graphicECS::SFML::Components;

--- a/libs/GraphicECS/SFML/Systems/InputManagement.cpp
+++ b/libs/GraphicECS/SFML/Systems/InputManagement.cpp
@@ -23,6 +23,7 @@
 #include "R-TypeLogic/Global/Components/ButtonComponent.hpp"
 #include "R-TypeLogic/Global/Components/ShootingFrequencyComponent.hpp"
 #include "R-TypeLogic/Global/SharedResources/GameClock.hpp"
+#include <boost/asio/thread_pool.hpp>
 
 using namespace graphicECS::SFML::Resources;
 using namespace graphicECS::SFML::Components;
@@ -31,8 +32,11 @@ namespace graphicECS::SFML::Systems
 {
     void InputManagement::_closeWindow(sf::Event &event, World &world)
     {
-        if (event.type == sf::Event::Closed)
-            world.getResource<RenderWindowResource>().window.close();
+        if (event.type == sf::Event::Closed) {
+            RenderWindowResource &windowResource = world.getResource<RenderWindowResource>();
+            auto guard = std::lock_guard(windowResource);
+            windowResource.window.close();
+        }
     }
 
     void InputManagement::_keyPressedEvents(sf::Event &event, std::vector<std::shared_ptr<Entity>> &Inputs)
@@ -88,8 +92,11 @@ namespace graphicECS::SFML::Systems
 
         if (Inputs.empty())
             return;
-        while (world.containsResource<RenderWindowResource>()
-            && world.getResource<RenderWindowResource>().window.pollEvent(event)) {
+        while (world.containsResource<RenderWindowResource>()) {
+            RenderWindowResource &windowResource = world.getResource<RenderWindowResource>();
+            auto guard = std::lock_guard(windowResource);
+            if (!windowResource.window.pollEvent(event))
+                break;
             _closeWindow(event, world);
             _keyPressedEvents(event, Inputs);
             _keyReleasedEvents(event, Inputs);
@@ -115,6 +122,7 @@ namespace graphicECS::SFML::Systems
         for (auto &player : players) {
             ShootingFrequency &freq = player->getComponent<ShootingFrequency>();
             GameClock &clock = world.getResource<GameClock>();
+            auto guard = std::lock_guard(clock);
             double delta = freq.frequency.count() - clock.getElapsedTime();
             freq.frequency = duration<double>(delta);
         }
@@ -160,6 +168,7 @@ namespace graphicECS::SFML::Systems
             ShootingFrequency &freq = entityPtr.get()->getComponent<ShootingFrequency>();
             const char hex_char[] = "0123456789ABCDEF";
             ecs::RandomDevice &random = world.getResource<RandomDevice>();
+            auto guard = std::lock_guard(random);
             std::string uuid(16, '\0');
 
             if (freq.frequency == duration<double>(0.0)) {
@@ -176,7 +185,9 @@ namespace graphicECS::SFML::Systems
     {
         (void)action;
         std::vector<std::shared_ptr<Entity>> joined = world.joinEntities<Button, Position, Size>();
-        sf::Vector2i mousePos = sf::Mouse::getPosition(world.getResource<RenderWindowResource>().window);
+        RenderWindowResource &windowResource = world.getResource<RenderWindowResource>();
+        auto guard = std::lock_guard(windowResource);
+        sf::Vector2i mousePos = sf::Mouse::getPosition(windowResource.window);
 
         auto clickInButton = [this, &world, &mousePos](std::shared_ptr<Entity> entityPtr) {
             Position &pos = entityPtr.get()->getComponent<Position>();
@@ -187,9 +198,9 @@ namespace graphicECS::SFML::Systems
             if (sameHeigth && sameWidth) {
                 ActionName &name = entityPtr.get()->getComponent<ActionName>();
                 ButtonActionMap &map = world.getResource<ButtonActionMap>();
+                auto guard = std::lock_guard(map);
 
                 std::function<void(World &)> fct = map.actionList.find(name.actionName)->second;
-
                 fct(world);
             }
         };

--- a/libs/GraphicECS/SFML/Systems/InputManagement.cpp
+++ b/libs/GraphicECS/SFML/Systems/InputManagement.cpp
@@ -7,6 +7,7 @@
 
 #include "InputManagement.hpp"
 #include <chrono>
+#include <mutex>
 #include <random>
 #include <string.h>
 #include "ActionQueueComponent.hpp"
@@ -23,8 +24,6 @@
 #include "R-TypeLogic/Global/Components/ButtonComponent.hpp"
 #include "R-TypeLogic/Global/Components/ShootingFrequencyComponent.hpp"
 #include "R-TypeLogic/Global/SharedResources/GameClock.hpp"
-#include <boost/asio/thread_pool.hpp>
-
 using namespace graphicECS::SFML::Resources;
 using namespace graphicECS::SFML::Components;
 

--- a/libs/R-TypeLogic/EntityManipulation/CreateEntitiesFunctions/CreateEnemy.cpp
+++ b/libs/R-TypeLogic/EntityManipulation/CreateEntitiesFunctions/CreateEnemy.cpp
@@ -6,6 +6,7 @@
 */
 
 #include "CreateEnemy.hpp"
+#include <boost/asio/thread_pool.hpp>
 
 namespace ecs
 {
@@ -27,11 +28,13 @@ namespace ecs
 
         if (networkId) {
             // Case : Creation in a server instance
+            RandomDevice &random = world.getResource<RandomDevice>();
+            auto guard = std::lock_guard(random);
             entity.addComponent<NewlyCreated>(uuid, false);
             entity.addComponent<Networkable>(networkId);
             entity.addComponent<ShootingFrequency>(1.3);
-            entity.addComponent<Destination>(world.getResource<RandomDevice>().randInt(MINIMUM_WIDTH, MAXIMUM_WIDTH),
-                world.getResource<RandomDevice>().randInt(MINIMUM_HEIGTH, MAXIMUM_HEIGTH));
+            entity.addComponent<Destination>(
+                random.randInt(MINIMUM_WIDTH, MAXIMUM_WIDTH), random.randInt(MINIMUM_HEIGTH, MAXIMUM_HEIGTH));
         } else {
             // Case : Creation in a Client instance
             if (uuid != "") {
@@ -47,8 +50,12 @@ namespace ecs
         const short weight, const int sizeX, const int sizeY, const unsigned short life, const unsigned short damage,
         const unsigned short damageRadius, const std::string uuid, const unsigned short networkId)
     {
-        return createNewEnemy(world, world.getResource<RandomDevice>().randInt(MINIMUM_WIDTH, MAXIMUM_WIDTH),
-            world.getResource<RandomDevice>().randInt(MINIMUM_HEIGTH, MAXIMUM_HEIGTH), multiplierAbscissa,
-            multiplierOrdinate, weight, sizeX, sizeY, life, damage, damageRadius, uuid, networkId);
+        RandomDevice &random = world.getResource<RandomDevice>();
+        random.lock();
+        int posX = random.randInt(MINIMUM_WIDTH, MAXIMUM_WIDTH);
+        int posY = random.randInt(MINIMUM_HEIGTH, MAXIMUM_HEIGTH);
+        random.unlock();
+        return createNewEnemy(world, posX, posY, multiplierAbscissa, multiplierOrdinate, weight, sizeX, sizeY, life,
+            damage, damageRadius, uuid, networkId);
     }
 } // namespace ecs

--- a/libs/R-TypeLogic/EntityManipulation/CreateEntitiesFunctions/CreateEnemy.cpp
+++ b/libs/R-TypeLogic/EntityManipulation/CreateEntitiesFunctions/CreateEnemy.cpp
@@ -6,7 +6,7 @@
 */
 
 #include "CreateEnemy.hpp"
-#include <boost/asio/thread_pool.hpp>
+#include <mutex>
 
 namespace ecs
 {

--- a/libs/R-TypeLogic/Global/Systems/MovementSystem.cpp
+++ b/libs/R-TypeLogic/Global/Systems/MovementSystem.cpp
@@ -6,14 +6,13 @@
 */
 
 #include "MovementSystem.hpp"
+#include <mutex>
 #include "R-TypeLogic/Global/Components/DestinationComponent.hpp"
 #include "R-TypeLogic/Global/Components/EnemyComponent.hpp"
 #include "R-TypeLogic/Global/Components/PlayerComponent.hpp"
 #include "R-TypeLogic/Global/Components/PositionComponent.hpp"
 #include "R-TypeLogic/Global/Components/VelocityComponent.hpp"
 #include "R-TypeLogic/Global/SharedResources/GameClock.hpp"
-#include <boost/asio/thread_pool.hpp>
-
 using namespace ecs;
 
 void Movement::run(World &world)

--- a/libs/R-TypeLogic/Global/Systems/MovementSystem.cpp
+++ b/libs/R-TypeLogic/Global/Systems/MovementSystem.cpp
@@ -12,6 +12,7 @@
 #include "R-TypeLogic/Global/Components/PositionComponent.hpp"
 #include "R-TypeLogic/Global/Components/VelocityComponent.hpp"
 #include "R-TypeLogic/Global/SharedResources/GameClock.hpp"
+#include <boost/asio/thread_pool.hpp>
 
 using namespace ecs;
 
@@ -21,6 +22,7 @@ void Movement::run(World &world)
 
     auto move = [&world](std::shared_ptr<ecs::Entity> entityPtr) {
         GameClock &clock = world.getResource<GameClock>();
+        auto guard = std::lock_guard(clock);
         double elapsedTimeInSeconds = clock.getElapsedTime();
         Position &pos = entityPtr.get()->getComponent<Position>();
         Velocity &vel = entityPtr.get()->getComponent<Velocity>();

--- a/libs/R-TypeLogic/Global/Systems/UpdateClockSystem.cpp
+++ b/libs/R-TypeLogic/Global/Systems/UpdateClockSystem.cpp
@@ -9,12 +9,14 @@
 #include <chrono>
 #include "R-TypeLogic/Global/Components/ShootingFrequencyComponent.hpp"
 #include "R-TypeLogic/Server/Components/AfkFrequencyComponent.hpp"
+#include <boost/asio/thread_pool.hpp>
 
 using namespace ecs;
 
 void UpdateClock::run(World &world)
 {
     GameClock &clock = world.getResource<GameClock>();
+    auto guard = std::lock_guard(clock);
     std::vector<std::shared_ptr<ecs::Entity>> joinedShoot = world.joinEntities<ShootingFrequency>();
     std::vector<std::shared_ptr<ecs::Entity>> joinedAfk = world.joinEntities<AfkFrequency>();
 

--- a/libs/R-TypeLogic/Global/Systems/UpdateClockSystem.cpp
+++ b/libs/R-TypeLogic/Global/Systems/UpdateClockSystem.cpp
@@ -7,10 +7,9 @@
 
 #include "UpdateClockSystem.hpp"
 #include <chrono>
+#include <mutex>
 #include "R-TypeLogic/Global/Components/ShootingFrequencyComponent.hpp"
 #include "R-TypeLogic/Server/Components/AfkFrequencyComponent.hpp"
-#include <boost/asio/thread_pool.hpp>
-
 using namespace ecs;
 
 void UpdateClock::run(World &world)

--- a/libs/R-TypeLogic/Server/Systems/DecreaseLifeTimeSystem.hpp
+++ b/libs/R-TypeLogic/Server/Systems/DecreaseLifeTimeSystem.hpp
@@ -8,6 +8,7 @@
 #ifndef DECREASELIFETIMESYSTEM_HPP_
 #define DECREASELIFETIMESYSTEM_HPP_
 
+#include <mutex>
 #include "World/World.hpp"
 #include "R-TypeLogic/Global/Components/DeathComponent.hpp"
 #include "R-TypeLogic/Global/Components/LifeTimeComponent.hpp"
@@ -23,8 +24,10 @@ namespace ecs
             std::vector<std::shared_ptr<ecs::Entity>> joined = world.joinEntities<LifeTime>();
 
             auto decreaseLifeTime = [&world](std::shared_ptr<ecs::Entity> entityPtr) {
+                GameClock &clock = world.getResource<GameClock>();
+                auto guard = std::lock_guard(clock);
                 entityPtr.get()->getComponent<LifeTime>() = entityPtr.get()->getComponent<LifeTime>().timeLeft
-                    - std::chrono::duration<double>(world.getResource<GameClock>().getElapsedTime());
+                    - std::chrono::duration<double>(clock.getElapsedTime());
             };
             std::for_each(joined.begin(), joined.end(), decreaseLifeTime);
         }

--- a/libs/R-TypeLogic/Server/Systems/EnemiesGoRandom.cpp
+++ b/libs/R-TypeLogic/Server/Systems/EnemiesGoRandom.cpp
@@ -11,6 +11,7 @@
 #include "R-TypeLogic/Global/Components/PositionComponent.hpp"
 #include "R-TypeLogic/Global/Components/VelocityComponent.hpp"
 #include "R-TypeLogic/Global/SharedResources/Random.hpp"
+#include <mutex>
 
 #define MINIMUM_WIDTH  1400
 #define MAXIMUM_WIDTH  1700
@@ -38,9 +39,10 @@ void EnemiesGoRandom::run(World &world)
         if (pos.x >= dest.x - 50 && pos.x <= dest.x + 50 && pos.y >= dest.y - 50 && pos.y <= dest.y + 50) {
             double newVelX = 0;
             double newVelY = 0;
-
-            dest.x = world.getResource<RandomDevice>().randInt(MINIMUM_WIDTH, MAXIMUM_WIDTH);
-            dest.y = world.getResource<RandomDevice>().randInt(MINIMUM_HEIGTH, MAXIMUM_HEIGTH);
+            RandomDevice &random = world.getResource<RandomDevice>();
+            auto guard = std::lock_guard(random);
+            dest.x = random.randInt(MINIMUM_WIDTH, MAXIMUM_WIDTH);
+            dest.y = random.randInt(MINIMUM_HEIGTH, MAXIMUM_HEIGTH);
             newVelX = dest.x - (int)pos.x;
             newVelY = dest.y - (int)pos.y;
             vel.multiplierAbscissa = (newVelX);

--- a/libs/R-TypeLogic/Server/Systems/EnemyShootSystem.cpp
+++ b/libs/R-TypeLogic/Server/Systems/EnemyShootSystem.cpp
@@ -7,6 +7,7 @@
 
 #include "EnemyShootSystem.hpp"
 #include <chrono>
+#include <mutex>
 #include "Transisthor/TransisthorECSLogic/Server/Resources/NetworkableIdGenerator.hpp"
 #include "R-TypeLogic/EntityManipulation/CreateEntitiesFunctions/CreateEnemyProjectile.hpp"
 #include "R-TypeLogic/Global/Components/EnemyComponent.hpp"
@@ -23,8 +24,9 @@ void EnemyShootSystem::run(World &world)
         ShootingFrequency &freq = entityPtr.get()->getComponent<ShootingFrequency>();
 
         if (freq.frequency == duration<double>(0)) {
-            createNewEnemyProjectile(
-                world, entityPtr, "", world.getResource<NetworkableIdGenerator>().generateNewNetworkableId());
+            NetworkableIdGenerator &generator = world.getResource<NetworkableIdGenerator>();
+            auto guard = std::lock_guard(generator);
+            createNewEnemyProjectile(world, entityPtr, "", generator.generateNewNetworkableId());
             freq.frequency = freq.baseFrequency;
         }
     };

--- a/libs/Transisthor/Transisthor.cpp
+++ b/libs/Transisthor/Transisthor.cpp
@@ -8,6 +8,7 @@
 /// @file libs/Transisthor/Transisthor.cpp
 
 #include "Transisthor.hpp"
+#include <mutex>
 #include "Error/Error.hpp"
 #include "TransisthorECSLogic/Both/Components/Networkable.hpp"
 #include "TransisthorECSLogic/Server/Resources/NetworkableIdGenerator.hpp"
@@ -17,7 +18,6 @@
 #include "R-TypeLogic/EntityManipulation/CreateEntitiesFunctions/CreateObstacle.hpp"
 #include "R-TypeLogic/EntityManipulation/CreateEntitiesFunctions/CreatePlayer.hpp"
 #include "R-TypeLogic/EntityManipulation/CreateEntitiesFunctions/CreateProjectile.hpp"
-#include "R-TypeLogic/Server/Components/AfkFrequencyComponent.hpp"
 #include "R-TypeLogic/Global/Components/DeathComponent.hpp"
 #include "R-TypeLogic/Global/Components/DestinationComponent.hpp"
 #include "R-TypeLogic/Global/Components/EquipmentComponent.hpp"
@@ -26,6 +26,7 @@
 #include "R-TypeLogic/Global/Components/LifeComponent.hpp"
 #include "R-TypeLogic/Global/Components/PositionComponent.hpp"
 #include "R-TypeLogic/Global/Components/VelocityComponent.hpp"
+#include "R-TypeLogic/Server/Components/AfkFrequencyComponent.hpp"
 
 using namespace transisthor_lib;
 using namespace error_lib;
@@ -395,8 +396,9 @@ void Transisthor::entityConvertAlliedProjectileType(unsigned short id, void *byt
 
     if (uuid != nullptr && id == 0) {
         uuid[16] = '\0';
-        createNewAlliedProjectile(_ecsWorld, *(shooter.get()), uuid,
-            _ecsWorld.getResource<NetworkableIdGenerator>().generateNewNetworkableId());
+        NetworkableIdGenerator &generator = _ecsWorld.getResource<NetworkableIdGenerator>();
+        auto guard = std::lock_guard(generator);
+        createNewAlliedProjectile(_ecsWorld, *(shooter.get()), uuid, generator.generateNewNetworkableId());
         shooter->getComponent<AfkFrequency>().frequency = shooter->getComponent<AfkFrequency>().baseFrequency;
     } else {
         std::size_t entityId;
@@ -450,8 +452,10 @@ void Transisthor::entityConvertEnemyType(unsigned short id, void *byteCode)
 
     std::string uuidStr(uuid);
     if (uuidStr != "" && id == 0) {
+        NetworkableIdGenerator &generator = _ecsWorld.getResource<NetworkableIdGenerator>();
+        auto guard = std::lock_guard(generator);
         createNewEnemy(_ecsWorld, posX, posY, multiplierAbscissa, multiplierOrdinate, weight, sizeX, sizeY, life,
-            damage, damageRadius, "", _ecsWorld.getResource<NetworkableIdGenerator>().generateNewNetworkableId());
+            damage, damageRadius, "", generator.generateNewNetworkableId());
     } else {
         std::size_t entityId;
 
@@ -486,8 +490,9 @@ void Transisthor::entityConvertEnemyProjectileType(unsigned short id, void *byte
 
     std::string uuidStr(uuid);
     if (uuidStr != "" && id == 0) {
-        createNewEnemyProjectile(
-            _ecsWorld, shooter, "", _ecsWorld.getResource<NetworkableIdGenerator>().generateNewNetworkableId());
+        NetworkableIdGenerator &generator = _ecsWorld.getResource<NetworkableIdGenerator>();
+        auto guard = std::lock_guard(generator);
+        createNewEnemyProjectile(_ecsWorld, shooter, "", generator.generateNewNetworkableId());
     } else {
         std::size_t entityId;
         entityId = createNewEnemyProjectile(_ecsWorld, shooter);
@@ -509,8 +514,9 @@ void Transisthor::entityConvertObstacleType(unsigned short id, void *byteCode)
     std::string uuidStr(uuid);
 
     if (uuidStr != "" && id == 0) {
-        createNewObstacle(_ecsWorld, posX, posY, damage, "",
-            _ecsWorld.getResource<NetworkableIdGenerator>().generateNewNetworkableId());
+        NetworkableIdGenerator &generator = _ecsWorld.getResource<NetworkableIdGenerator>();
+        auto guard = std::lock_guard(generator);
+        createNewObstacle(_ecsWorld, posX, posY, damage, "", generator.generateNewNetworkableId());
     } else {
         std::size_t entityId;
 
@@ -562,9 +568,10 @@ void Transisthor::entityConvertPlayerType(unsigned short id, void *byteCode)
     std::string uuidStr(uuid);
 
     if (uuidStr != "" && id == 0) {
+        NetworkableIdGenerator &generator = _ecsWorld.getResource<NetworkableIdGenerator>();
+        auto guard = std::lock_guard(generator);
         createNewPlayer(_ecsWorld, posX, posY, multiplierAbscissa, multiplierOrdinate, weight, sizeX, sizeY, life,
-            damage, damageRadius, false, playerIdentifier, "",
-            _ecsWorld.getResource<NetworkableIdGenerator>().generateNewNetworkableId());
+            damage, damageRadius, false, playerIdentifier, "", generator.generateNewNetworkableId());
     } else {
         std::size_t entityId;
 
@@ -592,8 +599,9 @@ void Transisthor::entityConvertProjectileType(unsigned short id, void *byteCode)
     std::string uuidStr(uuid);
 
     if (uuidStr != "" && id == 0) {
-        createNewProjectile(_ecsWorld, posX, posY, velAbsc, velOrd, damage, "",
-            _ecsWorld.getResource<NetworkableIdGenerator>().generateNewNetworkableId());
+        NetworkableIdGenerator &generator = _ecsWorld.getResource<NetworkableIdGenerator>();
+        auto guard = std::lock_guard(generator);
+        createNewProjectile(_ecsWorld, posX, posY, velAbsc, velOrd, damage, "", generator.generateNewNetworkableId());
     } else {
         std::size_t entityId;
 


### PR DESCRIPTION
## Purpose:
At the end of this pull request, a shared resource have to be locked before it can be used or modified. This issue prepares the future thread pool which will be implemented later.

### Added features:
- Lock the shared resources in the systems in the client's room
- Lock the shared resources in the systems in the library SFMLGraphicECS
- Lock the shared resources in the systems in the library RTypeLogicCreateEntitiesFunctions
- Lock the shared resources in the systems in the library RTypeLogicGlobal
- Lock the shared resources in the systems in the library RTypeLogicServer
- Lock the shared resources in the systems in the library Transisthor
- Lock the shared resources in the systems in the server

## **Warning**:
From now on, each shared resource must be locked before being used or modified !

This will close #240