### PR TITLE
147 implement switch to room protocol

### DIFF
--- a/Client/ClientRoom.cpp
+++ b/Client/ClientRoom.cpp
@@ -159,11 +159,16 @@ void ClientRoom::startLobbyLoop(void)
             }
             if (connectionOperation.message.type == 15)
                 _protocol15Answer(connectionOperation);
+            if (connectionOperation.message.type == 20) {
+                _serverEndpoint = _communicatorInstance->getClientByHisId(_communicatorInstance->getServerEndpointId());
+                break;
+            }
         } catch (NetworkError &error) {
         }
     }
     if (_state != ClientState::ENDED) {
         initEcsGameData();
+        _communicatorInstance.get()->sendDataToAClient(_serverEndpoint, nullptr, 0, 10);
         _state = ClientState::LOBBY;
     }
     while (_state != ClientState::ENDED && _state != ClientState::UNDEFINED) {

--- a/Client/ClientRoom.cpp
+++ b/Client/ClientRoom.cpp
@@ -136,6 +136,12 @@ void ClientRoom::_protocol15Answer(CommunicatorMessage connectionResponse)
 
     std::cin >> choosenRoomId; /// WILL BE REMOVED WHEN GRAPHICAL INTERACTION HAS BEEN IMPLEMENTED
     std::cerr << "Waiting for room number " << choosenRoomId << " answer..." << std::endl;
+    void *networkData = std::malloc(sizeof(unsigned short));
+
+    if (networkData == nullptr)
+        throw std::logic_error("Malloc failed.");
+    std::memcpy(networkData, &choosenRoomId, sizeof(unsigned short));
+    _communicatorInstance.get()->sendDataToAClient(_serverEndpoint, networkData, sizeof(unsigned short), 16);
 }
 
 void ClientRoom::startLobbyLoop(void)

--- a/Client/ClientRoom.cpp
+++ b/Client/ClientRoom.cpp
@@ -114,9 +114,23 @@ void ClientRoom::protocol12Answer(CommunicatorMessage connexionResponse)
 
 void ClientRoom::_protocol15Answer(CommunicatorMessage connectionResponse)
 {
-    (void)connectionResponse;
+    unsigned short roomNumber = 0;
+    std::size_t offset = sizeof(unsigned short);
+
+    std::memcpy(&roomNumber, connectionResponse.message.data, sizeof(unsigned short));
     std::cerr << "Succesfully connected to the hub." << std::endl;
     std::cerr << "Available Rooms : " << std::endl;
+    for (int i = 0; i < roomNumber; i++) {
+        unsigned short roomId = 0;
+        std::memcpy(&roomId, (void *)((char *)connectionResponse.message.data + offset), sizeof(unsigned short));
+        offset += sizeof(unsigned short);
+        char *tempRoomName = (char *)connectionResponse.message.data + offset;
+        std::string roomName(11, '\0');
+        for (int j = 0; j < 10; j++)
+            roomName[j] = tempRoomName[j];
+        offset += sizeof(char) * 10;
+        std::cerr << "\t" << roomId << " : " << roomName << " is available." << std::endl;
+    }
     std::cerr << "Refer in the terminal the wanted room id." << std::endl;
 }
 

--- a/Client/ClientRoom.cpp
+++ b/Client/ClientRoom.cpp
@@ -131,17 +131,43 @@ void ClientRoom::_protocol15Answer(CommunicatorMessage connectionResponse)
         offset += sizeof(char) * 10;
         std::cerr << "\t" << roomId << " : " << roomName << " is available." << std::endl;
     }
-    std::cerr << "Refer in the terminal the wanted room id : ";
-    unsigned short choosenRoomId = 0;
 
-    std::cin >> choosenRoomId; /// WILL BE REMOVED WHEN GRAPHICAL INTERACTION HAS BEEN IMPLEMENTED
-    std::cerr << "Waiting for room number " << choosenRoomId << " answer..." << std::endl;
-    void *networkData = std::malloc(sizeof(unsigned short));
+    std::cerr << "If you want to join a existent room, please refer Y. Otherwise use N : ";
+    char choosedMod = '\0';
 
-    if (networkData == nullptr)
-        throw std::logic_error("Malloc failed.");
-    std::memcpy(networkData, &choosenRoomId, sizeof(unsigned short));
-    _communicatorInstance.get()->sendDataToAClient(_serverEndpoint, networkData, sizeof(unsigned short), 16);
+    std::cin >> choosedMod;
+    if (choosedMod == 'Y') {
+        std::cerr << "Refer in the terminal the wanted room id : ";
+        unsigned short choosenRoomId = 0;
+
+        std::cin >> choosenRoomId; /// WILL BE REMOVED WHEN GRAPHICAL INTERACTION HAS BEEN IMPLEMENTED
+        std::cerr << "Waiting for room number " << choosenRoomId << " answer..." << std::endl;
+        void *networkData = std::malloc(sizeof(unsigned short));
+
+        if (networkData == nullptr)
+            throw std::logic_error("Malloc failed.");
+        std::memcpy(networkData, &choosenRoomId, sizeof(unsigned short));
+        _communicatorInstance.get()->sendDataToAClient(_serverEndpoint, networkData, sizeof(unsigned short), 16);
+    } else if (choosedMod == 'N') {
+        std::cerr << "Refer in the terminal the wanted room name : ";
+        std::string roomName;
+
+        std::cin >> roomName; /// WILL BE REMOVED WHEN GRAPHICAL INTERACTION HAS BEEN IMPLEMENTEND
+        if (roomName.size() != 10) {
+            std::cerr << "Please refer a valid room name (10 characters)." << std::endl;
+            _state = ClientState::ENDED;
+            return;
+        }
+        void *networkData = std::malloc(sizeof(char) * 10);
+
+        if (networkData == nullptr)
+            throw std::logic_error("Malloc failed.");
+        std::memcpy(networkData, roomName.c_str(), sizeof(char) * 10);
+        _communicatorInstance.get()->sendDataToAClient(_serverEndpoint, networkData, sizeof(char) * 10, 17);
+    } else {
+        std::cerr << "Not a valid option ;)" << std::endl;
+        _state = ClientState::ENDED;
+    }
 }
 
 void ClientRoom::startLobbyLoop(void)

--- a/Client/ClientRoom.cpp
+++ b/Client/ClientRoom.cpp
@@ -131,7 +131,11 @@ void ClientRoom::_protocol15Answer(CommunicatorMessage connectionResponse)
         offset += sizeof(char) * 10;
         std::cerr << "\t" << roomId << " : " << roomName << " is available." << std::endl;
     }
-    std::cerr << "Refer in the terminal the wanted room id." << std::endl;
+    std::cerr << "Refer in the terminal the wanted room id : ";
+    unsigned short choosenRoomId = 0;
+
+    std::cin >> choosenRoomId; /// WILL BE REMOVED WHEN GRAPHICAL INTERACTION HAS BEEN IMPLEMENTED
+    std::cerr << "Waiting for room number " << choosenRoomId << " answer..." << std::endl;
 }
 
 void ClientRoom::startLobbyLoop(void)

--- a/Client/ClientRoom.hpp
+++ b/Client/ClientRoom.hpp
@@ -95,6 +95,10 @@ namespace client_data
 
         /// @brief Answer the reception of a protocol 12
         void protocol12Answer(CommunicatorMessage connexionResponse);
+
+        /// @brief Answer the reception of a protocol 15
+        /// @param connectionResponse The received response
+        void _protocol15Answer(CommunicatorMessage connectionResponse);
     };
 } // namespace client_data
 

--- a/Server/Room.cpp
+++ b/Server/Room.cpp
@@ -68,9 +68,10 @@ Room::Room()
     _worldInstance.get()->setTransisthorBridge(_communicatorInstance.get()->getTransisthorBridge());
     _state = RoomState::UNDEFINED;
     _remainingPlaces = 4;
+    _name = std::string(10, '\0');
 }
 
-Room::Room(unsigned short id, Client networkInformations)
+Room::Room(unsigned short id, std::string name, Client networkInformations)
 {
     _id = id;
     _networkInformations = networkInformations;
@@ -81,6 +82,7 @@ Room::Room(unsigned short id, Client networkInformations)
     _worldInstance.get()->setTransisthorBridge(_communicatorInstance.get()->getTransisthorBridge());
     _state = RoomState::UNDEFINED;
     _remainingPlaces = 4;
+    _name = name;
 }
 
 void Room::initEcsGameData(void)

--- a/Server/Room.hpp
+++ b/Server/Room.hpp
@@ -123,6 +123,13 @@ namespace server_data
     /// @return true If the two rooms have the same id
     /// @return false If the two rooms have different id
     inline bool operator==(const Room &left, const unsigned short &right) { return ((left.getRoomId() == right)); }
+
+    /// @brief Overload of the == operator to compare rooms with her name
+    /// @param left param of the comparison
+    /// @param right param of the comparison
+    /// @return true If the two rooms have the same name
+    /// @return false If the two rooms have different name
+    inline bool operator==(const Room &left, const std::string &right) { return ((left.getRoomName() == right)); }
 } // namespace server_data
 
 #endif /* !ROOM_HPP_ */

--- a/Server/Room.hpp
+++ b/Server/Room.hpp
@@ -48,6 +48,10 @@ namespace server_data
         /// @return The room name
         inline std::string getRoomName(void) const { return _name; };
 
+        /// @brief Get the networkInformations of the room
+        /// @return The room networkInformations
+        inline Client getNetworkInformations(void) const { return _networkInformations; };
+
         /// @brief Start the loop function of the room. Warning, call it inside a thread
         void startLobbyLoop(void);
 

--- a/Server/Room.hpp
+++ b/Server/Room.hpp
@@ -112,6 +112,13 @@ namespace server_data
     /// @return true If the two rooms have the same id
     /// @return false If the two rooms have different id
     inline bool operator==(const Room &left, const Room &right) { return ((left.getRoomId() == right.getRoomId())); }
+
+    /// @brief Overload of the == operator to compare rooms with her id
+    /// @param left param of the comparison
+    /// @param right param of the comparison
+    /// @return true If the two rooms have the same id
+    /// @return false If the two rooms have different id
+    inline bool operator==(const Room &left, const unsigned short &right) { return ((left.getRoomId() == right)); }
 } // namespace server_data
 
 #endif /* !ROOM_HPP_ */

--- a/Server/Room.hpp
+++ b/Server/Room.hpp
@@ -127,8 +127,8 @@ namespace server_data
     /// @brief Overload of the == operator to compare rooms with her name
     /// @param left param of the comparison
     /// @param right param of the comparison
-    /// @return true If the two rooms have the same name
-    /// @return false If the two rooms have different name
+    /// @return true If the room have the good name
+    /// @return false If the room haven't the good name
     inline bool operator==(const Room &left, const std::string &right) { return ((left.getRoomName() == right)); }
 } // namespace server_data
 

--- a/Server/Room.hpp
+++ b/Server/Room.hpp
@@ -33,8 +33,9 @@ namespace server_data
 
         /// @brief Construct a new Room object
         /// @param id Id of the room
+        /// @param name of the room
         /// @param networkInformation Network informations of the room
-        Room(unsigned short id, Client networkInformations);
+        Room(unsigned short id, std::string name, Client networkInformations);
 
         /// @brief Destroy the Room object
         ~Room() = default;
@@ -43,12 +44,19 @@ namespace server_data
         /// @return The room id
         inline unsigned short getRoomId(void) const { return _id; };
 
+        /// @brief Get the room name
+        /// @return The room name
+        inline std::string getRoomName(void) const { return _name; };
+
         /// @brief Start the loop function of the room. Warning, call it inside a thread
         void startLobbyLoop(void);
 
       private:
         /// @brief Id of the room. (Used by the server)
         unsigned short _id;
+
+        /// @brief Name of the room.
+        std::string _name;
 
         /// @brief Network informations of the Room.
         Client _networkInformations;

--- a/Server/Server.cpp
+++ b/Server/Server.cpp
@@ -47,9 +47,7 @@ unsigned short Server::_getAFreePort(unsigned short actual)
 unsigned short Server::createANewRoom(std::string name)
 {
     _activeRoomList.push_back(Room(_activeRoomList.size() + 1, name,
-        Client(_networkInformations.getAddress(),
-            _getAFreePort(_networkInformations.getPort()
-                + 101)))); /// WILL BE REFACTO IN PART 2 TO AUTOMATIZE NEW FREE PORT DETECTION
+        Client(_networkInformations.getAddress(), _getAFreePort(_networkInformations.getPort() + 101))));
     return _activeRoomList.size();
 }
 

--- a/Server/Server.cpp
+++ b/Server/Server.cpp
@@ -14,16 +14,20 @@ using namespace server_data;
 using namespace error_lib;
 using namespace communicator_lib;
 
-Server::Server(std::string address, unsigned short port) : _communicatorInstance(Communicator(_networkInformations))
+Server::Server(std::string address, unsigned short port)
 {
     _activeRoomList = {};
     _networkInformations = Client(address, port);
+    _state = HubState::UNDEFINED;
+    _communicatorInstance = std::make_shared<Communicator>(_networkInformations);
 }
 
 Server::Server()
 {
     _activeRoomList = {};
     _networkInformations = Client();
+    _state = HubState::UNDEFINED;
+    _communicatorInstance = std::make_shared<Communicator>(_networkInformations);
 }
 
 unsigned short Server::createANewRoom(std::string name)
@@ -32,8 +36,50 @@ unsigned short Server::createANewRoom(std::string name)
         Client(_networkInformations.getAddress(),
             _networkInformations.getPort()
                 + 1000))); /// WILL BE REFACTO IN PART 2 TO AUTOMATIZE NEW FREE PORT DETECTION
-    _activeRoomList.back().startLobbyLoop();
+    //_activeRoomList.back().startLobbyLoop();
     return _activeRoomList.size() - 1;
+}
+
+void Server::_startConnexionProtocol()
+{
+    _communicatorInstance.get()->startReceiverListening();
+    _state = HubState::HUB;
+}
+
+void Server::startHubLoop()
+{
+    CommunicatorMessage connectionOperation;
+
+    _startConnexionProtocol();
+    while (_state != HubState::UNDEFINED && _state != HubState::ENDED) {
+        try {
+            connectionOperation = _communicatorInstance.get()->getLastMessage();
+            if (connectionOperation.message.type == 14)
+                _holdANewConnectionRequest(connectionOperation);
+            if (connectionOperation.message.type == 13)
+                _holdADisconnectionRequest(connectionOperation);
+        } catch (NetworkError &error) {
+        }
+    }
+    _disconnectionProcess();
+}
+
+void Server::_disconnectionProcess()
+{
+    auto clientList = _communicatorInstance.get()->getClientList();
+
+    for (auto it : clientList)
+        _communicatorInstance.get()->sendDataToAClient(it, nullptr, 0, 13);
+}
+
+void Server::_holdADisconnectionRequest(CommunicatorMessage disconnectionDemand)
+{
+    _communicatorInstance.get()->sendDataToAClient(disconnectionDemand.message.clientInfo, nullptr, 0, 13);
+}
+
+void Server::_holdANewConnectionRequest(CommunicatorMessage connectionDemand)
+{
+    _communicatorInstance.get()->sendDataToAClient(connectionDemand.message.clientInfo, nullptr, 0, 15);
 }
 
 void Server::deleteARoom(unsigned short id)

--- a/Server/Server.cpp
+++ b/Server/Server.cpp
@@ -84,11 +84,14 @@ void Server::_holdAJoinRoomRequest(CommunicatorMessage joinDemand)
     unsigned short choosenRoom = 0;
 
     std::memcpy(&choosenRoom, joinDemand.message.data, sizeof(unsigned short));
-    auto founded = std::find(_activeRoomList.begin(), _activeRoomList.end(), choosenRoom);
-
-    if (founded == _activeRoomList.end())
-        _communicatorInstance.get()->sendDataToAClient(joinDemand.message.clientInfo, nullptr, 0, 11);
-    /// SWITCH PROTOCOL
+    for (auto it : _activeRoomList) {
+        if (it == choosenRoom) {
+            _communicatorInstance.get()->kickAClient(joinDemand.message.clientInfo, it.getNetworkInformations());
+            it.startLobbyLoop(); /// WILL BE REMOVED WITH PROCESS IMPLEMENTATION
+            return;
+        }
+    }
+    _communicatorInstance.get()->sendDataToAClient(joinDemand.message.clientInfo, nullptr, 0, 11);
 }
 
 void Server::_holdANewConnectionRequest(CommunicatorMessage connectionDemand)

--- a/Server/Server.cpp
+++ b/Server/Server.cpp
@@ -26,9 +26,9 @@ Server::Server()
     _networkInformations = Client();
 }
 
-unsigned short Server::createANewRoom(void)
+unsigned short Server::createANewRoom(std::string name)
 {
-    _activeRoomList.push_back(Room(_activeRoomList.size(),
+    _activeRoomList.push_back(Room(_activeRoomList.size(), name,
         Client(_networkInformations.getAddress(),
             _networkInformations.getPort()
                 + 1000))); /// WILL BE REFACTO IN PART 2 TO AUTOMATIZE NEW FREE PORT DETECTION

--- a/Server/Server.cpp
+++ b/Server/Server.cpp
@@ -30,13 +30,26 @@ Server::Server()
     _communicatorInstance = std::make_shared<Communicator>(_networkInformations);
 }
 
+unsigned short Server::_getAFreePort(unsigned short actual)
+{
+    try {
+        boost::asio::io_service io_service;
+        boost::asio::ip::udp::socket socket(io_service);
+        socket.open(boost::asio::ip::udp::v4());
+        socket.bind(boost::asio::ip::udp::endpoint(
+            boost::asio::ip::address::from_string(_networkInformations.getAddress()), actual));
+        return actual;
+    } catch (const boost::system::system_error &error) {
+        return _getAFreePort(actual + 101);
+    }
+}
+
 unsigned short Server::createANewRoom(std::string name)
 {
     _activeRoomList.push_back(Room(_activeRoomList.size() + 1, name,
         Client(_networkInformations.getAddress(),
-            _networkInformations.getPort()
-                + 1000))); /// WILL BE REFACTO IN PART 2 TO AUTOMATIZE NEW FREE PORT DETECTION
-    //_activeRoomList.back().startLobbyLoop();
+            _getAFreePort(_networkInformations.getPort()
+                + 101)))); /// WILL BE REFACTO IN PART 2 TO AUTOMATIZE NEW FREE PORT DETECTION
     return _activeRoomList.size();
 }
 

--- a/Server/Server.cpp
+++ b/Server/Server.cpp
@@ -32,12 +32,12 @@ Server::Server()
 
 unsigned short Server::createANewRoom(std::string name)
 {
-    _activeRoomList.push_back(Room(_activeRoomList.size(), name,
+    _activeRoomList.push_back(Room(_activeRoomList.size() + 1, name,
         Client(_networkInformations.getAddress(),
             _networkInformations.getPort()
                 + 1000))); /// WILL BE REFACTO IN PART 2 TO AUTOMATIZE NEW FREE PORT DETECTION
     //_activeRoomList.back().startLobbyLoop();
-    return _activeRoomList.size() - 1;
+    return _activeRoomList.size();
 }
 
 void Server::_startConnexionProtocol()
@@ -94,7 +94,7 @@ void Server::_holdANewConnectionRequest(CommunicatorMessage connectionDemand)
 
         std::memcpy((void *)((char *)networkData + offset), &roomId, sizeof(unsigned short));
         offset += sizeof(unsigned short);
-        std::memcpy((void *)((char *)networkData + offset), &roomName, sizeof(char) * 10);
+        std::memcpy((void *)((char *)networkData + offset), roomName.c_str(), sizeof(char) * 10);
         offset += sizeof(char) * 10;
     }
     _communicatorInstance.get()->sendDataToAClient(connectionDemand.message.clientInfo, networkData, offset, 15);

--- a/Server/Server.hpp
+++ b/Server/Server.hpp
@@ -62,7 +62,7 @@ namespace server_data
         std::shared_ptr<Communicator> _communicatorInstance;
 
         /// @brief Cross all machine port and find an empty one
-        /// @param actual port number (+ 100 per iteration)
+        /// @param actual port number (+ 101 per iteration)
         /// @return the first empty port founded
         unsigned short _getAFreePort(unsigned short actual);
 

--- a/Server/Server.hpp
+++ b/Server/Server.hpp
@@ -61,6 +61,10 @@ namespace server_data
         /// @brief Instance of the communicator library
         std::shared_ptr<Communicator> _communicatorInstance;
 
+        /// @brief Cross all machine port and find an empty one
+        /// @param actual port number (+ 100 per iteration)
+        unsigned short _getAFreePort(unsigned short actual);
+
         /// @brief Start the connexion protocol and ask the server for a place inside the room
         void _startConnexionProtocol();
 

--- a/Server/Server.hpp
+++ b/Server/Server.hpp
@@ -76,6 +76,11 @@ namespace server_data
         /// @param joinDemand actual message data
         void _holdAJoinRoomRequest(CommunicatorMessage joinDemand);
 
+        /// @brief Handle a create room request. Check if the room already exist, otherwise launch it and send a
+        /// protocol 20
+        /// @param createDemand actual message data
+        void _holdACreateRoomRequest(CommunicatorMessage createDemand);
+
         /// @brief Send to all clients the disconnection signal
         void _disconnectionProcess();
     };

--- a/Server/Server.hpp
+++ b/Server/Server.hpp
@@ -63,6 +63,7 @@ namespace server_data
 
         /// @brief Cross all machine port and find an empty one
         /// @param actual port number (+ 100 per iteration)
+        /// @return the first empty port founded
         unsigned short _getAFreePort(unsigned short actual);
 
         /// @brief Start the connexion protocol and ask the server for a place inside the room

--- a/Server/Server.hpp
+++ b/Server/Server.hpp
@@ -22,6 +22,9 @@ namespace server_data
     /// @brief Main class of the server part. Hold room process.
     class Server {
       public:
+        /// @brief All the possible state of a room
+        enum HubState { UNDEFINED, HUB, ENDED };
+
         /// @brief Construct a new server object
         /// @param address Ip address of the server
         /// @param port Listening port for network process
@@ -38,11 +41,17 @@ namespace server_data
         /// @return Id of the newly created room
         unsigned short createANewRoom(std::string name);
 
+        /// @brief Start the hub global loop
+        void startHubLoop();
+
         /// @brief Remove and delete a room of the list
         /// @param id of the room to be deleted
         void deleteARoom(unsigned short id);
 
       private:
+        /// @brief Current state of the server
+        HubState _state;
+
         /// @brief List of all the active room.
         std::vector<Room> _activeRoomList;
 
@@ -50,7 +59,21 @@ namespace server_data
         Client _networkInformations;
 
         /// @brief Instance of the communicator library
-        Communicator _communicatorInstance;
+        std::shared_ptr<Communicator> _communicatorInstance;
+
+        /// @brief Start the connexion protocol and ask the server for a place inside the room
+        void _startConnexionProtocol();
+
+        /// @brief Handle a connection request. Send all rooms informations (id + name) to the client.
+        /// @param connectionDemand actual message data
+        void _holdANewConnectionRequest(CommunicatorMessage connectionDemand);
+
+        /// @brief Handle a disconnection request. Send a protocol 13.
+        /// @param connectionDemand actual message data
+        void _holdADisconnectionRequest(CommunicatorMessage disconnectionDemand);
+
+        /// @brief Send to all clients the disconnection signal
+        void _disconnectionProcess();
     };
 } // namespace server_data
 

--- a/Server/Server.hpp
+++ b/Server/Server.hpp
@@ -72,6 +72,10 @@ namespace server_data
         /// @param connectionDemand actual message data
         void _holdADisconnectionRequest(CommunicatorMessage disconnectionDemand);
 
+        /// @brief Handle a joining room request. Identifiy the room and send a protocol 20
+        /// @param joinDemand actual message data
+        void _holdAJoinRoomRequest(CommunicatorMessage joinDemand);
+
         /// @brief Send to all clients the disconnection signal
         void _disconnectionProcess();
     };

--- a/Server/Server.hpp
+++ b/Server/Server.hpp
@@ -34,8 +34,9 @@ namespace server_data
         ~Server() = default;
 
         /// @brief Create and add a new Room inside the room list
-        /// @brief Id of the newly created room
-        unsigned short createANewRoom(void);
+        /// @param name of the room
+        /// @return Id of the newly created room
+        unsigned short createANewRoom(std::string name);
 
         /// @brief Remove and delete a room of the list
         /// @param id of the room to be deleted

--- a/Server/Server.hpp
+++ b/Server/Server.hpp
@@ -69,7 +69,8 @@ namespace server_data
         /// @brief Start the connexion protocol and ask the server for a place inside the room
         void _startConnexionProtocol();
 
-        /// @brief Handle a connection request. Send all rooms informations (id + name) to the client.
+        /// @brief Handle a connection request. Send all rooms informations (id + name) to the client. Send a protocol
+        /// 15
         /// @param connectionDemand actual message data
         void _holdANewConnectionRequest(CommunicatorMessage connectionDemand);
 

--- a/Server/main.cpp
+++ b/Server/main.cpp
@@ -19,5 +19,6 @@ int main(int ac, char **av)
     Server server = Server(serverInformation.address, serverInformation.port);
 
     server.createANewRoom("SleepLucas");
+    server.startHubLoop();
     return 0;
 }

--- a/Server/main.cpp
+++ b/Server/main.cpp
@@ -18,6 +18,6 @@ int main(int ac, char **av)
     ArgumentHandler::ServerInformation serverInformation = argumentHandler.extractServerInformation();
     Server server = Server(serverInformation.address, serverInformation.port);
 
-    server.createANewRoom();
+    server.createANewRoom("SleepLucas");
     return 0;
 }

--- a/Server/main.cpp
+++ b/Server/main.cpp
@@ -19,6 +19,7 @@ int main(int ac, char **av)
     Server server = Server(serverInformation.address, serverInformation.port);
 
     server.createANewRoom("SleepLucas");
+    server.createANewRoom("GetUpLucas");
     server.startHubLoop();
     return 0;
 }

--- a/libs/Communicator/Communicator.cpp
+++ b/libs/Communicator/Communicator.cpp
@@ -33,7 +33,7 @@ void Communicator::addClientToList(Client &client)
 {
     if (std::find(_clientList.begin(), _clientList.end(), client) != _clientList.end())
         throw NetworkError("Client already registered in the communicator.", "Communicator.cpp -> addClientToList");
-    client.setId(_clientList.size() + 1);
+    client.setId(_clientList.size());
     _clientList.push_back(client);
 }
 
@@ -101,6 +101,7 @@ void Communicator::kickAClient(Client client, Client newEndpoint)
         return;
     }
     sendProtocol20(client, newEndpoint);
+    std::cerr << "Removed : " << client.getId() << std::endl;
     removeClientFromList(client);
     _receiverModule.removeAllClientMessage(client);
     std::cerr << "You have asked a client to switch to a new communicator." << std::endl;
@@ -160,7 +161,6 @@ Client Communicator::getClientByHisId(unsigned short id)
             return it;
     }
     throw NetworkError("No matched client founded.", "Communicator.cpp -> getClientByHisId");
-    return Client();
 }
 
 unsigned short Communicator::getServerEndpointId(void)

--- a/libs/Communicator/Receiver.cpp
+++ b/libs/Communicator/Receiver.cpp
@@ -161,6 +161,12 @@ void Receiver::dataTraitmentType16(Message dataContent)
         dataContent.size - NETWORK_HEADER_SIZE, 16});
 }
 
+void Receiver::dataTraitmentType17(Message dataContent)
+{
+    addMessage({dataContent.clientInfo, (void *)((char *)dataContent.data + NETWORK_HEADER_SIZE),
+        dataContent.size - NETWORK_HEADER_SIZE, 17});
+}
+
 void Receiver::dataTraitmentType20(Message dataContent)
 {
     unsigned short endpointPort = 0;
@@ -197,8 +203,9 @@ void Receiver::bindDataTraitmentFunction(void)
     _dataTraitment[12] = std::bind(&Receiver::dataTraitmentType12, this, std::placeholders::_1);
     _dataTraitment[13] = std::bind(&Receiver::dataTraitmentType13, this, std::placeholders::_1);
     _dataTraitment[14] = std::bind(&Receiver::dataTraitmentType14, this, std::placeholders::_1);
-    _dataTraitment[15] = std::bind(&Receiver::dataTraitmentType14, this, std::placeholders::_1);
-    _dataTraitment[16] = std::bind(&Receiver::dataTraitmentType14, this, std::placeholders::_1);
+    _dataTraitment[15] = std::bind(&Receiver::dataTraitmentType15, this, std::placeholders::_1);
+    _dataTraitment[16] = std::bind(&Receiver::dataTraitmentType16, this, std::placeholders::_1);
+    _dataTraitment[17] = std::bind(&Receiver::dataTraitmentType17, this, std::placeholders::_1);
     _dataTraitment[20] = std::bind(&Receiver::dataTraitmentType20, this, std::placeholders::_1);
     _dataTraitment[21] = std::bind(&Receiver::dataTraitmentType21, this, std::placeholders::_1);
     _dataTraitment[30] = std::bind(&Receiver::dataTraitmentType30, this, std::placeholders::_1);

--- a/libs/Communicator/Receiver.cpp
+++ b/libs/Communicator/Receiver.cpp
@@ -155,6 +155,12 @@ void Receiver::dataTraitmentType15(Message dataContent)
         dataContent.size - NETWORK_HEADER_SIZE, 15});
 }
 
+void Receiver::dataTraitmentType16(Message dataContent)
+{
+    addMessage({dataContent.clientInfo, (void *)((char *)dataContent.data + NETWORK_HEADER_SIZE),
+        dataContent.size - NETWORK_HEADER_SIZE, 16});
+}
+
 void Receiver::dataTraitmentType20(Message dataContent)
 {
     unsigned short endpointPort = 0;
@@ -192,6 +198,7 @@ void Receiver::bindDataTraitmentFunction(void)
     _dataTraitment[13] = std::bind(&Receiver::dataTraitmentType13, this, std::placeholders::_1);
     _dataTraitment[14] = std::bind(&Receiver::dataTraitmentType14, this, std::placeholders::_1);
     _dataTraitment[15] = std::bind(&Receiver::dataTraitmentType14, this, std::placeholders::_1);
+    _dataTraitment[16] = std::bind(&Receiver::dataTraitmentType14, this, std::placeholders::_1);
     _dataTraitment[20] = std::bind(&Receiver::dataTraitmentType20, this, std::placeholders::_1);
     _dataTraitment[21] = std::bind(&Receiver::dataTraitmentType21, this, std::placeholders::_1);
     _dataTraitment[30] = std::bind(&Receiver::dataTraitmentType30, this, std::placeholders::_1);

--- a/libs/Communicator/Receiver.cpp
+++ b/libs/Communicator/Receiver.cpp
@@ -149,6 +149,12 @@ void Receiver::dataTraitmentType14(Message dataContent)
         dataContent.size - NETWORK_HEADER_SIZE, 14});
 }
 
+void Receiver::dataTraitmentType15(Message dataContent)
+{
+    addMessage({dataContent.clientInfo, (void *)((char *)dataContent.data + NETWORK_HEADER_SIZE),
+        dataContent.size - NETWORK_HEADER_SIZE, 15});
+}
+
 void Receiver::dataTraitmentType20(Message dataContent)
 {
     unsigned short endpointPort = 0;
@@ -185,6 +191,7 @@ void Receiver::bindDataTraitmentFunction(void)
     _dataTraitment[12] = std::bind(&Receiver::dataTraitmentType12, this, std::placeholders::_1);
     _dataTraitment[13] = std::bind(&Receiver::dataTraitmentType13, this, std::placeholders::_1);
     _dataTraitment[14] = std::bind(&Receiver::dataTraitmentType14, this, std::placeholders::_1);
+    _dataTraitment[15] = std::bind(&Receiver::dataTraitmentType14, this, std::placeholders::_1);
     _dataTraitment[20] = std::bind(&Receiver::dataTraitmentType20, this, std::placeholders::_1);
     _dataTraitment[21] = std::bind(&Receiver::dataTraitmentType21, this, std::placeholders::_1);
     _dataTraitment[30] = std::bind(&Receiver::dataTraitmentType30, this, std::placeholders::_1);

--- a/libs/Communicator/Receiver.cpp
+++ b/libs/Communicator/Receiver.cpp
@@ -143,6 +143,12 @@ void Receiver::dataTraitmentType13(Message dataContent)
         dataContent.size - NETWORK_HEADER_SIZE, 13});
 }
 
+void Receiver::dataTraitmentType14(Message dataContent)
+{
+    addMessage({dataContent.clientInfo, (void *)((char *)dataContent.data + NETWORK_HEADER_SIZE),
+        dataContent.size - NETWORK_HEADER_SIZE, 14});
+}
+
 void Receiver::dataTraitmentType20(Message dataContent)
 {
     unsigned short endpointPort = 0;
@@ -178,6 +184,7 @@ void Receiver::bindDataTraitmentFunction(void)
     _dataTraitment[11] = std::bind(&Receiver::dataTraitmentType11, this, std::placeholders::_1);
     _dataTraitment[12] = std::bind(&Receiver::dataTraitmentType12, this, std::placeholders::_1);
     _dataTraitment[13] = std::bind(&Receiver::dataTraitmentType13, this, std::placeholders::_1);
+    _dataTraitment[14] = std::bind(&Receiver::dataTraitmentType14, this, std::placeholders::_1);
     _dataTraitment[20] = std::bind(&Receiver::dataTraitmentType20, this, std::placeholders::_1);
     _dataTraitment[21] = std::bind(&Receiver::dataTraitmentType21, this, std::placeholders::_1);
     _dataTraitment[30] = std::bind(&Receiver::dataTraitmentType30, this, std::placeholders::_1);

--- a/libs/Communicator/Receiver.hpp
+++ b/libs/Communicator/Receiver.hpp
@@ -130,6 +130,10 @@ namespace communicator_lib
         /// @param dataContent The transfered data (Client + Data)
         void dataTraitmentType16(Message dataContent);
 
+        /// @brief The function will process the data according to the protocol 17
+        /// @param dataContent The transfered data (Client + Data)
+        void dataTraitmentType17(Message dataContent);
+
         /// @brief The function will process the data according to the protocol 20
         /// @param dataContent The transfered data (Client + Data)
         void dataTraitmentType20(Message dataContent);

--- a/libs/Communicator/Receiver.hpp
+++ b/libs/Communicator/Receiver.hpp
@@ -118,6 +118,10 @@ namespace communicator_lib
         /// @param dataContent The transfered data (Client + Data)
         void dataTraitmentType13(Message dataContent);
 
+        /// @brief The function will process the data according to the protocol 14
+        /// @param dataContent The transfered data (Client + Data)
+        void dataTraitmentType14(Message dataContent);
+
         /// @brief The function will process the data according to the protocol 20
         /// @param dataContent The transfered data (Client + Data)
         void dataTraitmentType20(Message dataContent);

--- a/libs/Communicator/Receiver.hpp
+++ b/libs/Communicator/Receiver.hpp
@@ -122,6 +122,10 @@ namespace communicator_lib
         /// @param dataContent The transfered data (Client + Data)
         void dataTraitmentType14(Message dataContent);
 
+        /// @brief The function will process the data according to the protocol 15
+        /// @param dataContent The transfered data (Client + Data)
+        void dataTraitmentType15(Message dataContent);
+
         /// @brief The function will process the data according to the protocol 20
         /// @param dataContent The transfered data (Client + Data)
         void dataTraitmentType20(Message dataContent);

--- a/libs/Communicator/Receiver.hpp
+++ b/libs/Communicator/Receiver.hpp
@@ -126,6 +126,10 @@ namespace communicator_lib
         /// @param dataContent The transfered data (Client + Data)
         void dataTraitmentType15(Message dataContent);
 
+        /// @brief The function will process the data according to the protocol 16
+        /// @param dataContent The transfered data (Client + Data)
+        void dataTraitmentType16(Message dataContent);
+
         /// @brief The function will process the data according to the protocol 20
         /// @param dataContent The transfered data (Client + Data)
         void dataTraitmentType20(Message dataContent);

--- a/tests/unit_tests/Transisthor_tests/Transisthor_tests.cpp
+++ b/tests/unit_tests/Transisthor_tests/Transisthor_tests.cpp
@@ -50,7 +50,7 @@ Test(transisthor_testing, transit_position_component)
     Position newPos;
     Client temporaryClient = Client();
     communicator.addClientToList(temporaryClient);
-    void *temp = transisthor.transitEcsDataToNetworkData<Position>(1, 6, pos, {1});
+    void *temp = transisthor.transitEcsDataToNetworkData<Position>(1, 6, pos, {0});
     void *networkAnswer = transisthor.transitNetworkDataToEcsDataComponent({Client(), temp, sizeof(Position), 30});
 
     cr_assert_eq(pos.x, 10);
@@ -69,7 +69,7 @@ Test(transisthor_testing, transit_destination_component)
     Destination newPos;
     Client temporaryClient = Client();
     communicator.addClientToList(temporaryClient);
-    void *temp = transisthor.transitEcsDataToNetworkData<Destination>(1, 1, pos, {1});
+    void *temp = transisthor.transitEcsDataToNetworkData<Destination>(1, 1, pos, {0});
     void *networkAnswer = transisthor.transitNetworkDataToEcsDataComponent({Client(), temp, sizeof(Destination), 30});
 
     cr_assert_eq(pos.x, 10);
@@ -88,7 +88,7 @@ Test(transisthor_testing, transit_equipment_component)
     Equipment newPos;
     Client temporaryClient = Client();
     communicator.addClientToList(temporaryClient);
-    void *temp = transisthor.transitEcsDataToNetworkData<Equipment>(1, 2, pos, {1});
+    void *temp = transisthor.transitEcsDataToNetworkData<Equipment>(1, 2, pos, {0});
     void *networkAnswer = transisthor.transitNetworkDataToEcsDataComponent({Client(), temp, sizeof(Equipment), 30});
 
     cr_assert_eq(pos.typeId, 10);
@@ -105,7 +105,7 @@ Test(transisthor_testing, transit_invinsible_component)
     Invinsible newPos;
     Client temporaryClient = Client();
     communicator.addClientToList(temporaryClient);
-    void *temp = transisthor.transitEcsDataToNetworkData<Invinsible>(1, 3, pos, {1});
+    void *temp = transisthor.transitEcsDataToNetworkData<Invinsible>(1, 3, pos, {0});
     void *networkAnswer = transisthor.transitNetworkDataToEcsDataComponent({Client(), temp, sizeof(Invinsible), 30});
 
     newPos = buildComponentFromByteCode<Invinsible>(networkAnswer);
@@ -121,7 +121,7 @@ Test(transisthor_testing, transit_invisible_component)
     Invisible newPos;
     Client temporaryClient = Client();
     communicator.addClientToList(temporaryClient);
-    void *temp = transisthor.transitEcsDataToNetworkData<Invisible>(1, 4, pos, {1});
+    void *temp = transisthor.transitEcsDataToNetworkData<Invisible>(1, 4, pos, {0});
     void *networkAnswer = transisthor.transitNetworkDataToEcsDataComponent({Client(), temp, sizeof(Invisible), 30});
 
     newPos = buildComponentFromByteCode<Invisible>(networkAnswer);
@@ -137,7 +137,7 @@ Test(transisthor_testing, transit_life_component)
     Life newPos;
     Client temporaryClient = Client();
     communicator.addClientToList(temporaryClient);
-    void *temp = transisthor.transitEcsDataToNetworkData<Life>(1, 5, pos, {1});
+    void *temp = transisthor.transitEcsDataToNetworkData<Life>(1, 5, pos, {0});
     void *networkAnswer = transisthor.transitNetworkDataToEcsDataComponent({Client(), temp, sizeof(Life), 30});
 
     cr_assert_eq(pos.lifePoint, 10);
@@ -154,7 +154,7 @@ Test(transisthor_testing, transit_velocity_component)
     Velocity newPos;
     Client temporaryClient = Client();
     communicator.addClientToList(temporaryClient);
-    void *temp = transisthor.transitEcsDataToNetworkData<Velocity>(1, 7, pos, {1});
+    void *temp = transisthor.transitEcsDataToNetworkData<Velocity>(1, 7, pos, {0});
     void *networkAnswer = transisthor.transitNetworkDataToEcsDataComponent({Client(), temp, sizeof(Velocity), 30});
 
     cr_assert_eq(pos.multiplierOrdinate, 12);
@@ -173,7 +173,7 @@ Test(transisthor_testing, transit_death_component)
     Death newDeath;
     Client temporaryClient = Client();
     communicator.addClientToList(temporaryClient);
-    void *temp = transisthor.transitEcsDataToNetworkData<Death>(1, 8, death, {1});
+    void *temp = transisthor.transitEcsDataToNetworkData<Death>(1, 8, death, {0});
     void *networkAnswer = transisthor.transitNetworkDataToEcsDataComponent({Client(), temp, sizeof(Death), 30});
 
     cr_assert_eq(death.modified, true);
@@ -188,7 +188,7 @@ Test(transisthor_testing, transit_to_a_non_valid_client)
     Transisthor transisthor = Transisthor(communicator, world);
     Velocity pos = Velocity(10, 12);
     try {
-        void *temp = transisthor.transitEcsDataToNetworkData<Velocity>(1, 7, pos, {1});
+        void *temp = transisthor.transitEcsDataToNetworkData<Velocity>(1, 7, pos, {0});
         (void)temp;
         cr_assert_eq(41, 42);
     } catch (NetworkError &err) {
@@ -262,7 +262,7 @@ Test(transisthor_testing, transit_enemy_entity)
     Position entityPosition = world.getEntity(entityId).getComponent<Position>();
 
     void *temp = transisthor.transitEcsDataToNetworkDataEntityEnemy(
-        entityId, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, std::string("UUID"), {1});
+        entityId, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, std::string("UUID"), {0});
     void *networkAnswer = transisthor.transitNetworkDataToEcsDataEntity({Client(), temp, 1, 31});
 
     int posX = 0;
@@ -328,7 +328,7 @@ Test(transisthor_testing, transit_enemy_entity_without_uuid)
     Position entityPosition = world.getEntity(entityId).getComponent<Position>();
 
     void *temp = transisthor.transitEcsDataToNetworkDataEntityEnemy(
-        entityId, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, std::string(""), {1});
+        entityId, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, std::string(""), {0});
     void *networkAnswer = transisthor.transitNetworkDataToEcsDataEntity({Client(), temp, 1, 31});
 
     int posX = 0;
@@ -390,7 +390,7 @@ Test(transisthor_testing, transit_player_entity)
     std::size_t entityId = createNewPlayer(world, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, false, 2, "UUID");
 
     void *temp = transisthor.transitEcsDataToNetworkDataEntityPlayer(
-        entityId, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, false, 2, std::string("UUID"), {1});
+        entityId, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, false, 2, std::string("UUID"), {0});
     void *networkAnswer = transisthor.transitNetworkDataToEcsDataEntity({Client(), temp, 1, 31});
 
     int posX = 0;
@@ -464,7 +464,7 @@ Test(transisthor_testing, transit_player_entity_without_uuid)
     std::size_t entityId = createNewPlayer(world, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, false, 2, "", 1);
 
     void *temp = transisthor.transitEcsDataToNetworkDataEntityPlayer(
-        entityId, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, false, 2, std::string(""), {1});
+        entityId, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, false, 2, std::string(""), {0});
     void *networkAnswer = transisthor.transitNetworkDataToEcsDataEntity({Client(), temp, 1, 31});
 
     int posX = 0;
@@ -544,7 +544,7 @@ Test(transisthor_testing, transit_alliedProjectile_entity)
 
     unsigned short entityId = createNewAlliedProjectile(world, world.getEntity(allied), "UUID", 1);
 
-    void *temp = transisthor.transitEcsDataToNetworkDataEntityAlliedProjectile(entityId, 10, std::string("UUID"), {1});
+    void *temp = transisthor.transitEcsDataToNetworkDataEntityAlliedProjectile(entityId, 10, std::string("UUID"), {0});
     void *networkAnswer = transisthor.transitNetworkDataToEcsDataEntity({Client(), temp, 1, 31});
 
     unsigned short newAllied = 0;
@@ -574,7 +574,7 @@ Test(transisthor_testing, transit_alliedProjectile_entity_empty_uuid)
 
     unsigned short entityId = createNewAlliedProjectile(world, world.getEntity(allied), "", 1);
 
-    void *temp = transisthor.transitEcsDataToNetworkDataEntityAlliedProjectile(entityId, 10, std::string(""), {1});
+    void *temp = transisthor.transitEcsDataToNetworkDataEntityAlliedProjectile(entityId, 10, std::string(""), {0});
     (void)temp;
     cr_assert_eq(42, 42);
 }
@@ -599,7 +599,7 @@ Test(transisthor_testing, transit_enemyProjectile_entity)
     std::vector<std::shared_ptr<ecs::Entity>> joined = world.joinEntities<Damage>();
 
     unsigned short entityId = createNewEnemyProjectile(world, joined.at(0), "UUID");
-    void *temp = transisthor.transitEcsDataToNetworkDataEntityEnemyProjectile(entityId, 10, std::string("UUID"), {1});
+    void *temp = transisthor.transitEcsDataToNetworkDataEntityEnemyProjectile(entityId, 10, std::string("UUID"), {0});
     (void)temp;
     void *networkAnswer = transisthor.transitNetworkDataToEcsDataEntity({Client(), temp, 1, 31});
 
@@ -633,7 +633,7 @@ Test(transisthor_testing, transit_enemyProjectile_entity_without_uuid)
 
     unsigned short entityId = createNewEnemyProjectile(world, joined.at(0), "", 1);
 
-    void *temp = transisthor.transitEcsDataToNetworkDataEntityEnemyProjectile(entityId, enemy, std::string(""), {1});
+    void *temp = transisthor.transitEcsDataToNetworkDataEntityEnemyProjectile(entityId, enemy, std::string(""), {0});
     (void)temp;
     cr_assert_eq(42, 42);
 }
@@ -653,7 +653,7 @@ Test(transisthor_testing, transit_obstacle_entity)
     Position entityPosition = world.getEntity(entityId).getComponent<Position>();
 
     void *temp = transisthor.transitEcsDataToNetworkDataEntityObstacle(
-        entityId, entityPosition.x, entityPosition.y, 5, std::string("UUID"), {1});
+        entityId, entityPosition.x, entityPosition.y, 5, std::string("UUID"), {0});
     void *networkAnswer = transisthor.transitNetworkDataToEcsDataEntity({Client(), temp, 1, 31});
 
     int posX = 0;
@@ -686,7 +686,7 @@ Test(transisthor_testing, transit_obstacle_entity_without_uuid)
     Position entityPosition = world.getEntity(entityId).getComponent<Position>();
 
     void *temp = transisthor.transitEcsDataToNetworkDataEntityObstacle(
-        entityId, entityPosition.x, entityPosition.y, 5, std::string(""), {1});
+        entityId, entityPosition.x, entityPosition.y, 5, std::string(""), {0});
     void *networkAnswer = transisthor.transitNetworkDataToEcsDataEntity({Client(), temp, 1, 31});
 
     int posX = 0;
@@ -720,7 +720,7 @@ Test(transisthor_testing, transit_projectile_entity)
     Velocity entityVel = world.getEntity(entityId).getComponent<Velocity>();
 
     void *temp = transisthor.transitEcsDataToNetworkDataEntityProjectile(entityId, entityPosition.x, entityPosition.y,
-        entityVel.multiplierAbscissa, entityVel.multiplierOrdinate, 1, std::string("UUID"), {1});
+        entityVel.multiplierAbscissa, entityVel.multiplierOrdinate, 1, std::string("UUID"), {0});
     void *networkAnswer = transisthor.transitNetworkDataToEcsDataEntity({Client(), temp, 1, 31});
 
     int posX = 0;
@@ -761,7 +761,7 @@ Test(transisthor_testing, transit_projectile_entity_without_uuid)
     Velocity entityVel = world.getEntity(entityId).getComponent<Velocity>();
 
     void *temp = transisthor.transitEcsDataToNetworkDataEntityProjectile(entityId, entityPosition.x, entityPosition.y,
-        entityVel.multiplierAbscissa, entityVel.multiplierOrdinate, 1, std::string(""), {1});
+        entityVel.multiplierAbscissa, entityVel.multiplierOrdinate, 1, std::string(""), {0});
     void *networkAnswer = transisthor.transitNetworkDataToEcsDataEntity({Client(), temp, 1, 31});
 
     int posX = 0;


### PR DESCRIPTION
Rebase of the Hub, Lobby and Room system.

Hub implementation :
- At his creation, the server know handle a hub global loop, which interacts with a communicator instance.
- The hub can handle several clients and dispatch them to different rooms in terms of theirs request.
- Hub can also handle player disconnection / refusal when no places left (or missing performance)

Lobby rebase :
- At his creation a client is now connected to a hub. He receive the list of all the active rooms (Id + name) and can choose to create / join one of this room.
- Client can now create a room and joined it instantly by specifying name of the newly created room. 
- Client can now join a current room by specifying the wanted room id.
- Protocol 2X of communicator is now fully used and the network is switched correctly.

Room rebase :
- At creation, two rooms is available.
- A room need to have a name of strictly 10 characters.
- When a new room is add inside the server, a empty port is now automatically binded.
- Some verification (Like bad ID, same Name, etc...) is implemented to protect the server integrity.
- Everything is now setup to add a graphical interface for replacing the textual one.

WARNING : When this PR's will be merged, multiple client connection and server SigInt will be not functional. This is normal. Everything is gonna return at normal when the rooming process issue will be done.

Enjoy your new triple AAA game ! :)