### PR TITLE
264 animate a player

### DIFF
--- a/Client/ClientRoom.cpp
+++ b/Client/ClientRoom.cpp
@@ -26,6 +26,7 @@
 #include "GraphicECS/SFML/Resources/GraphicsFontResource.hpp"
 #include "GraphicECS/SFML/Resources/GraphicsTextureResource.hpp"
 #include "GraphicECS/SFML/Resources/RenderWindowResource.hpp"
+#include "GraphicECS/SFML/Systems/AnimationSystem.hpp"
 #include "GraphicECS/SFML/Systems/DrawComponents.hpp"
 #include "GraphicECS/SFML/Systems/InputManagement.hpp"
 #include "GraphicECS/SFML/Systems/ParallaxSystem.hpp"
@@ -154,8 +155,22 @@ void ClientRoom::_initSpritesForEntities()
     GraphicsTextureResource &spritesList = _worldInstance->getResource<GraphicsTextureResource>();
     auto guard = std::lock_guard(spritesList);
 
-    spritesList.addTexture(GraphicsTextureResource::PLAYER_STATIC, "assets/EpiSprite/BasicPlayerSpriteSheet.gif",
-        sf::Vector2f(500, 0), sf::Vector2f(500, 34));
+    spritesList.addTexture(GraphicsTextureResource::PLAYER_STATIC_1, "assets/EpiSprite/BasicPlayerSpriteSheet.gif",
+        sf::Vector2f(534 / 16 * 8, 0), sf::Vector2f(534 / 16, 34));
+    spritesList.addTexture(GraphicsTextureResource::PLAYER_STATIC_2, "assets/EpiSprite/BasicPlayerSpriteSheet.gif",
+        sf::Vector2f(534 / 16 * 9, 0), sf::Vector2f(534 / 16, 34));
+    spritesList.addTexture(GraphicsTextureResource::PLAYER_STATIC_3, "assets/EpiSprite/BasicPlayerSpriteSheet.gif",
+        sf::Vector2f(534 / 16 * 10, 0), sf::Vector2f(534 / 16, 34));
+    spritesList.addTexture(GraphicsTextureResource::PLAYER_STATIC_4, "assets/EpiSprite/BasicPlayerSpriteSheet.gif",
+        sf::Vector2f(534 / 16 * 11, 0), sf::Vector2f(534 / 16, 34));
+    spritesList.addTexture(GraphicsTextureResource::PLAYER_STATIC_5, "assets/EpiSprite/BasicPlayerSpriteSheet.gif",
+        sf::Vector2f(534 / 16 * 12, 0), sf::Vector2f(534 / 16, 34));
+    spritesList.addTexture(GraphicsTextureResource::PLAYER_STATIC_6, "assets/EpiSprite/BasicPlayerSpriteSheet.gif",
+        sf::Vector2f(534 / 16 * 13, 0), sf::Vector2f(534 / 16, 34));
+    spritesList.addTexture(GraphicsTextureResource::PLAYER_STATIC_7, "assets/EpiSprite/BasicPlayerSpriteSheet.gif",
+        sf::Vector2f(534 / 16 * 14, 0), sf::Vector2f(534 / 16, 34));
+    spritesList.addTexture(GraphicsTextureResource::PLAYER_STATIC_8, "assets/EpiSprite/BasicPlayerSpriteSheet.gif",
+        sf::Vector2f(534 / 16 * 15, 0), sf::Vector2f(534 / 16, 34));
     spritesList.addTexture(GraphicsTextureResource::PROJECTILE_ENEMY,
         "assets/EpiSprite/BasicEnemyProjectileSpriteSheet.gif", sf::Vector2f(0, 0), sf::Vector2f(34, 34));
     spritesList.addTexture(GraphicsTextureResource::PROJECTILE_ALLY,
@@ -190,6 +205,7 @@ void ClientRoom::_initSystems()
     _worldInstance->addSystem<SfRectangleFollowEntitySystem>();
     _worldInstance->addSystem<Parallax>();
     _worldInstance->addSystem<Movement>();
+    _worldInstance->addSystem<AnimationSystem>();
 }
 
 void ClientRoom::_initBackgroundEntities()

--- a/libs/GraphicECS/SFML/Components/AnimationComponent.hpp
+++ b/libs/GraphicECS/SFML/Components/AnimationComponent.hpp
@@ -21,7 +21,7 @@ namespace graphicECS::SFML::Components
         std::vector<graphicECS::SFML::Resources::GraphicsTextureResource::textureName_e> textures;
 
         /// @brief Index of the current texture in use.
-        graphicECS::SFML::Resources::GraphicsTextureResource::textureName_e currentTexture;
+        std::size_t currentTexturePos;
 
         /// @brief Default constructor of AnimationComponent.
         AnimationComponent() = default;

--- a/libs/GraphicECS/SFML/Components/AnimationFrequencyComponent.hpp
+++ b/libs/GraphicECS/SFML/Components/AnimationFrequencyComponent.hpp
@@ -16,15 +16,15 @@ namespace graphicECS::SFML::Components
     /// @brief This component allows to know the frequency between each frame of an animation.
     class AnimationFrequencyComponent : public ecs::Component {
       public:
-        /// @brief The frequency between each frame of an animation as milliseconds.
+        /// @brief The frequency between each frame of an animation as seconds.
         std::chrono::duration<double> frequency;
 
-        /// @brief The default frequency of the animation as milliseconds.
+        /// @brief The default frequency of the animation as seconds.
         const std::chrono::duration<double> baseFrequency;
 
         /// @brief Construct the class to set default values.
-        /// @param d Frequency to set the baseFrequency of the animation. Default value is 500.0 milliseconds.
-        AnimationFrequencyComponent(const double &d = 500.0)
+        /// @param d Frequency to set the baseFrequency of the animation. Default value is 0.5 seconds.
+        AnimationFrequencyComponent(const double &d = 0.5)
             : frequency(std::chrono::duration<double>(d)), baseFrequency(std::chrono::duration<double>(d)){};
 
         /// @brief Default destructor.

--- a/libs/GraphicECS/SFML/Resources/GraphicsTextureResource.hpp
+++ b/libs/GraphicECS/SFML/Resources/GraphicsTextureResource.hpp
@@ -22,7 +22,14 @@ namespace graphicECS::SFML::Resources
         /// @brief Enumeration of all available Textures
         enum textureName_e {
             UNDEFINED,
-            PLAYER_STATIC,
+            PLAYER_STATIC_1,
+            PLAYER_STATIC_2,
+            PLAYER_STATIC_3,
+            PLAYER_STATIC_4,
+            PLAYER_STATIC_5,
+            PLAYER_STATIC_6,
+            PLAYER_STATIC_7,
+            PLAYER_STATIC_8,
             PLAYER_UP,
             PLAYER_DOWN,
             ENEMY_STATIC,

--- a/libs/GraphicECS/SFML/Systems/AnimationSystem.cpp
+++ b/libs/GraphicECS/SFML/Systems/AnimationSystem.cpp
@@ -27,17 +27,18 @@ void AnimationSystem::run(World &world)
     for (auto entity : shapes) {
         using texturesNamesVector = std::vector<GraphicsTextureResource::textureName_e>;
         using texturesMap = std::unordered_map<GraphicsTextureResource::textureName_e, std::shared_ptr<sf::Texture>>;
-        auto guard = std::lock_guard(*entity.get());
+        auto entityGuard = std::lock_guard(*entity.get());
         {
-            auto guard = std::lock_guard(world.getResource<GameClock>());
+            auto &clock = world.getResource<GameClock>();
+            auto clockGuard = std::lock_guard(clock);
             entity->getComponent<AnimationFrequencyComponent>().frequency -=
-                std::chrono::duration<double>(world.getResource<GameClock>().getElapsedTime());
+                std::chrono::duration<double>(clock.getElapsedTime());
         }
         if (entity->getComponent<AnimationFrequencyComponent>().frequency < std::chrono::duration<double>(0)) {
             texturesNamesVector texturesNames = entity->getComponent<AnimationComponent>().textures;
             std::size_t &currentTexturePos = entity->getComponent<AnimationComponent>().currentTexturePos;
             {
-                auto guard = std::lock_guard(world.getResource<GraphicsTextureResource>());
+                auto textureGuard = std::lock_guard(world.getResource<GraphicsTextureResource>());
                 texturesMap textures = world.getResource<GraphicsTextureResource>()._texturesList;
 
                 currentTexturePos = (currentTexturePos < texturesNames.size() - 1) ? currentTexturePos + 1 : 0;

--- a/libs/GraphicECS/SFML/Systems/AnimationSystem.cpp
+++ b/libs/GraphicECS/SFML/Systems/AnimationSystem.cpp
@@ -38,8 +38,9 @@ void AnimationSystem::run(World &world)
             texturesNamesVector texturesNames = entity->getComponent<AnimationComponent>().textures;
             std::size_t &currentTexturePos = entity->getComponent<AnimationComponent>().currentTexturePos;
             {
-                auto textureGuard = std::lock_guard(world.getResource<GraphicsTextureResource>());
-                texturesMap textures = world.getResource<GraphicsTextureResource>()._texturesList;
+                auto &textureResource = world.getResource<GraphicsTextureResource>();
+                auto textureGuard = std::lock_guard(textureResource);
+                texturesMap textures = textureResource._texturesList;
 
                 currentTexturePos = (currentTexturePos < texturesNames.size() - 1) ? currentTexturePos + 1 : 0;
                 entity->getComponent<GraphicsRectangleComponent>().shape.setTexture(

--- a/libs/GraphicECS/SFML/Systems/AnimationSystem.cpp
+++ b/libs/GraphicECS/SFML/Systems/AnimationSystem.cpp
@@ -27,9 +27,9 @@ void AnimationSystem::run(World &world)
     for (auto entity : shapes) {
         using texturesNamesVector = std::vector<GraphicsTextureResource::textureName_e>;
         using texturesMap = std::unordered_map<GraphicsTextureResource::textureName_e, std::shared_ptr<sf::Texture>>;
-        std::lock_guard(*entity.get());
+        auto guard = std::lock_guard(*entity.get());
         {
-            std::lock_guard(world.getResource<GameClock>());
+            auto guard = std::lock_guard(world.getResource<GameClock>());
             entity->getComponent<AnimationFrequencyComponent>().frequency -=
                 std::chrono::duration<double>(world.getResource<GameClock>().getElapsedTime());
         }
@@ -37,7 +37,7 @@ void AnimationSystem::run(World &world)
             texturesNamesVector texturesNames = entity->getComponent<AnimationComponent>().textures;
             std::size_t &currentTexturePos = entity->getComponent<AnimationComponent>().currentTexturePos;
             {
-                std::lock_guard(world.getResource<GraphicsTextureResource>());
+                auto guard = std::lock_guard(world.getResource<GraphicsTextureResource>());
                 texturesMap textures = world.getResource<GraphicsTextureResource>()._texturesList;
 
                 currentTexturePos = (currentTexturePos < texturesNames.size() - 1) ? currentTexturePos + 1 : 0;

--- a/libs/GraphicECS/SFML/Systems/AnimationSystem.cpp
+++ b/libs/GraphicECS/SFML/Systems/AnimationSystem.cpp
@@ -22,23 +22,24 @@ void AnimationSystem::run(World &world)
     std::vector<std::shared_ptr<Entity>> shapes =
         world.joinEntities<GraphicsRectangleComponent, AnimationComponent, AnimationFrequencyComponent>();
 
-    auto shape = [&world](std::shared_ptr<Entity> entity) {
+    if (shapes.empty())
+        return;
+    for (auto entity : shapes) {
         using texturesNamesVector = std::vector<GraphicsTextureResource::textureName_e>;
         using texturesMap = std::unordered_map<GraphicsTextureResource::textureName_e, std::shared_ptr<sf::Texture>>;
         std::lock_guard(*entity.get());
         entity->getComponent<AnimationFrequencyComponent>().frequency -= std::chrono::duration<double>(world.getResource<GameClock>().getElapsedTime());
         if (entity->getComponent<AnimationFrequencyComponent>().frequency < std::chrono::duration<double>(0)) {
             texturesNamesVector texturesNames = entity->getComponent<AnimationComponent>().textures;
-            GraphicsTextureResource::textureName_e &currentTexture =
-                entity->getComponent<AnimationComponent>().currentTexture;
+            std::size_t &currentTexturePos =
+                entity->getComponent<AnimationComponent>().currentTexturePos;
             texturesMap textures = world.getResource<GraphicsTextureResource>()._texturesList;
 
-            currentTexture = (currentTexture < textures.size())
-                ? GraphicsTextureResource::textureName_e(currentTexture + 1)
-                : GraphicsTextureResource::textureName_e(0);
-            entity->getComponent<GraphicsRectangleComponent>().shape.setTexture(textures.at(currentTexture).get());
+            currentTexturePos = (currentTexturePos < texturesNames.size() - 1)
+                ? currentTexturePos + 1
+                : 0;
+            entity->getComponent<GraphicsRectangleComponent>().shape.setTexture(textures.at(texturesNames[currentTexturePos]).get());
             entity->getComponent<AnimationFrequencyComponent>().frequency = entity->getComponent<AnimationFrequencyComponent>().baseFrequency;
         }
-    };
-    std::for_each(shapes.begin(), shapes.end(), shape);
+    }
 }

--- a/libs/GraphicECS/SFML/Systems/AnimationSystem.cpp
+++ b/libs/GraphicECS/SFML/Systems/AnimationSystem.cpp
@@ -5,8 +5,8 @@
 ** AnimationSystem
 */
 
-#include <mutex>
 #include "AnimationSystem.hpp"
+#include <mutex>
 #include "AnimationComponent.hpp"
 #include "AnimationFrequencyComponent.hpp"
 #include "GraphicsRectangleComponent.hpp"
@@ -28,18 +28,24 @@ void AnimationSystem::run(World &world)
         using texturesNamesVector = std::vector<GraphicsTextureResource::textureName_e>;
         using texturesMap = std::unordered_map<GraphicsTextureResource::textureName_e, std::shared_ptr<sf::Texture>>;
         std::lock_guard(*entity.get());
-        entity->getComponent<AnimationFrequencyComponent>().frequency -= std::chrono::duration<double>(world.getResource<GameClock>().getElapsedTime());
+        {
+            std::lock_guard(world.getResource<GameClock>());
+            entity->getComponent<AnimationFrequencyComponent>().frequency -=
+                std::chrono::duration<double>(world.getResource<GameClock>().getElapsedTime());
+        }
         if (entity->getComponent<AnimationFrequencyComponent>().frequency < std::chrono::duration<double>(0)) {
             texturesNamesVector texturesNames = entity->getComponent<AnimationComponent>().textures;
-            std::size_t &currentTexturePos =
-                entity->getComponent<AnimationComponent>().currentTexturePos;
-            texturesMap textures = world.getResource<GraphicsTextureResource>()._texturesList;
+            std::size_t &currentTexturePos = entity->getComponent<AnimationComponent>().currentTexturePos;
+            {
+                std::lock_guard(world.getResource<GraphicsTextureResource>());
+                texturesMap textures = world.getResource<GraphicsTextureResource>()._texturesList;
 
-            currentTexturePos = (currentTexturePos < texturesNames.size() - 1)
-                ? currentTexturePos + 1
-                : 0;
-            entity->getComponent<GraphicsRectangleComponent>().shape.setTexture(textures.at(texturesNames[currentTexturePos]).get());
-            entity->getComponent<AnimationFrequencyComponent>().frequency = entity->getComponent<AnimationFrequencyComponent>().baseFrequency;
+                currentTexturePos = (currentTexturePos < texturesNames.size() - 1) ? currentTexturePos + 1 : 0;
+                entity->getComponent<GraphicsRectangleComponent>().shape.setTexture(
+                    textures.at(texturesNames[currentTexturePos]).get());
+            }
+            entity->getComponent<AnimationFrequencyComponent>().frequency =
+                entity->getComponent<AnimationFrequencyComponent>().baseFrequency;
         }
     }
 }

--- a/libs/GraphicECS/SFML/Systems/DrawComponents.cpp
+++ b/libs/GraphicECS/SFML/Systems/DrawComponents.cpp
@@ -13,6 +13,8 @@
 #include "GraphicsTextComponent.hpp"
 #include "GraphicsTextureResource.hpp"
 #include "TextureName.hpp"
+#include "AnimationComponent.hpp"
+#include "AnimationFrequencyComponent.hpp"
 #include "R-TypeLogic/Global/Components/AlliedProjectileComponent.hpp"
 #include "R-TypeLogic/Global/Components/EnemyProjectileComponent.hpp"
 #include "R-TypeLogic/Global/Components/LayerLvL.hpp"
@@ -42,8 +44,13 @@ void DrawComponents::run(World &world)
                 if (world.containsResource<GraphicsTextureResource>()) {
                     GraphicsTextureResource &textureResource = world.getResource<GraphicsTextureResource>();
                     auto guard = std::lock_guard(textureResource);
-                    entityPtr->getComponent<GraphicsRectangleComponent>().shape.setTexture(
-                        textureResource._texturesList[entityPtr->getComponent<TextureName>().textureName].get());
+                    if (entityPtr->contains<TextureName>()) {
+                        entityPtr->getComponent<GraphicsRectangleComponent>().shape.setTexture(
+                            textureResource._texturesList[entityPtr->getComponent<TextureName>().textureName].get());
+                    } else if (entityPtr->contains<AnimationComponent>()) {
+                        entityPtr->getComponent<GraphicsRectangleComponent>().shape.setTexture(
+                            textureResource._texturesList[entityPtr->getComponent<AnimationComponent>().textures[entityPtr->getComponent<AnimationComponent>().currentTexturePos]].get());
+                    }
                 } else {
                     entityPtr->getComponent<GraphicsRectangleComponent>().shape.setFillColor(sf::Color::White);
                 }
@@ -63,8 +70,19 @@ void DrawComponents::run(World &world)
 
                 entityPtr->addComponent<GraphicsRectangleComponent>(
                     entityPos.x, entityPos.y, entitySize.x, entitySize.y);
-                if (layerType.layer == LayerLvL::layer_e::PLAYER)
-                    entityPtr->addComponent<TextureName>(GraphicsTextureResource::PLAYER_STATIC);
+                if (layerType.layer == LayerLvL::layer_e::PLAYER) {
+                    entityPtr->addComponent<AnimationComponent>();
+                    entityPtr->addComponent<AnimationFrequencyComponent>(0.005);
+                    entityPtr->getComponent<AnimationComponent>().currentTexturePos = 0;
+                    entityPtr->getComponent<AnimationComponent>().textures.push_back(GraphicsTextureResource::PLAYER_STATIC_1);
+                    entityPtr->getComponent<AnimationComponent>().textures.push_back(GraphicsTextureResource::PLAYER_STATIC_2);
+                    entityPtr->getComponent<AnimationComponent>().textures.push_back(GraphicsTextureResource::PLAYER_STATIC_3);
+                    entityPtr->getComponent<AnimationComponent>().textures.push_back(GraphicsTextureResource::PLAYER_STATIC_4);
+                    entityPtr->getComponent<AnimationComponent>().textures.push_back(GraphicsTextureResource::PLAYER_STATIC_5);
+                    entityPtr->getComponent<AnimationComponent>().textures.push_back(GraphicsTextureResource::PLAYER_STATIC_6);
+                    entityPtr->getComponent<AnimationComponent>().textures.push_back(GraphicsTextureResource::PLAYER_STATIC_7);
+                    entityPtr->getComponent<AnimationComponent>().textures.push_back(GraphicsTextureResource::PLAYER_STATIC_8);
+                }
                 if (layerType.layer == LayerLvL::layer_e::ENEMY)
                     entityPtr->addComponent<TextureName>(GraphicsTextureResource::ENEMY_STATIC);
                 if (layerType.layer == LayerLvL::layer_e::PROJECTILE) {


### PR DESCRIPTION
## New features
- Use animation system and components to animate the player.
- Load new texture for the player animation.
- Create new textureName enumerator.
- Use animationComponent and AnimationFrequencyComponent instead of textureName on player to animate him.
## Updated features
- Use an index to store actual position during the animation in AnimationComponent.
- Update AnimationFrequencyComponent documentation.
- Change default value for the AnimationFrequencyComponent frequency.
## Fixed features
- Fix crash in AnimationSystem