### PR TITLE
322 updgrade writable entity

### DIFF
--- a/Client/ButtonAction.cpp
+++ b/Client/ButtonAction.cpp
@@ -61,6 +61,7 @@ void selectAWritable(World &world, Entity &entityPtr)
 {
     RenderWindowResource &resource = world.getResource<RenderWindowResource>();
     if (entityPtr.contains<Selected>()) {
+        auto guardOld = std::lock_guard(entityPtr);
         entityPtr.removeComponent<Selected>();
         if (entityPtr.contains<TextureName>()) {
             entityPtr.removeComponent<TextureName>();
@@ -73,6 +74,16 @@ void selectAWritable(World &world, Entity &entityPtr)
         return;
     }
     resource.window.setKeyRepeatEnabled(true);
+    auto joined = world.joinEntities<Selected, WritableContent>();
+    if (!joined.empty()) {
+        auto guardOld = std::lock_guard(*(joined.at(0)));
+        joined.at(0)->removeComponent<Selected>();
+        if (joined.at(0)->contains<TextureName>()) {
+            joined.at(0)->removeComponent<TextureName>();
+            joined.at(0)->addComponent<TextureName>(GraphicsTextureResource::WRITABLE);
+        }
+    }
+    auto guardNew = std::lock_guard(entityPtr);
     entityPtr.addComponent<Selected>();
     if (entityPtr.contains<TextureName>()) {
         entityPtr.removeComponent<TextureName>();

--- a/Client/ButtonAction.cpp
+++ b/Client/ButtonAction.cpp
@@ -64,8 +64,7 @@ void selectAWritable(World &world, Entity &entityPtr)
         auto guardOld = std::lock_guard(entityPtr);
         entityPtr.removeComponent<Selected>();
         if (entityPtr.contains<TextureName>()) {
-            entityPtr.removeComponent<TextureName>();
-            entityPtr.addComponent<TextureName>(GraphicsTextureResource::WRITABLE);
+            entityPtr.getComponent<TextureName>().textureName = GraphicsTextureResource::WRITABLE;
         }
         auto &state = world.getResource<GameStates>();
         auto guard = std::lock_guard(state);
@@ -78,16 +77,13 @@ void selectAWritable(World &world, Entity &entityPtr)
     if (!joined.empty()) {
         auto guardOld = std::lock_guard(*(joined.at(0)));
         joined.at(0)->removeComponent<Selected>();
-        if (joined.at(0)->contains<TextureName>()) {
-            joined.at(0)->removeComponent<TextureName>();
-            joined.at(0)->addComponent<TextureName>(GraphicsTextureResource::WRITABLE);
-        }
+        if (joined.at(0)->contains<TextureName>())
+            joined.at(0)->getComponent<TextureName>().textureName = GraphicsTextureResource::WRITABLE;
     }
     auto guardNew = std::lock_guard(entityPtr);
     entityPtr.addComponent<Selected>();
     if (entityPtr.contains<TextureName>()) {
-        entityPtr.removeComponent<TextureName>();
-        entityPtr.addComponent<TextureName>(GraphicsTextureResource::WRITABLE_SELECTED);
+        entityPtr.getComponent<TextureName>().textureName = GraphicsTextureResource::WRITABLE_SELECTED;
     }
     auto &state = world.getResource<GameStates>();
     auto guard = std::lock_guard(state);

--- a/libs/GraphicECS/SFML/Systems/InputManagement.cpp
+++ b/libs/GraphicECS/SFML/Systems/InputManagement.cpp
@@ -16,6 +16,7 @@
 #include "ControllerButtonInputComponent.hpp"
 #include "ControllerJoystickInputComponent.hpp"
 #include "GraphicECS/SFML/Components/GraphicsTextComponent.hpp"
+#include "GraphicECS/SFML/Components/TextureName.hpp"
 #include "IsShootingComponent.hpp"
 #include "KeyboardInputComponent.hpp"
 #include "MouseInputComponent.hpp"
@@ -85,6 +86,10 @@ namespace graphicECS::SFML::Systems
                 } else if (event.text.unicode == 13) {
                     auto guard = std::lock_guard(*entityPtr.get());
                     entityPtr->removeComponent<Selected>();
+                    if (entityPtr->contains<TextureName>()) {
+                        entityPtr->removeComponent<TextureName>();
+                        entityPtr->addComponent<TextureName>(GraphicsTextureResource::WRITABLE);
+                    }
                     return;
                 } else if (event.text.unicode != 8) {
                     auto guard = std::lock_guard(*entityPtr.get());

--- a/libs/GraphicECS/SFML/Systems/InputManagement.cpp
+++ b/libs/GraphicECS/SFML/Systems/InputManagement.cpp
@@ -82,6 +82,10 @@ namespace graphicECS::SFML::Systems
                 if (event.text.unicode == 8 && writableContent.content.size() != 0) {
                     auto guard = std::lock_guard(*entityPtr.get());
                     writableContent.content.pop_back();
+                } else if (event.text.unicode == 13) {
+                    auto guard = std::lock_guard(*entityPtr.get());
+                    entityPtr->removeComponent<Selected>();
+                    return;
                 } else if (event.text.unicode != 8) {
                     auto guard = std::lock_guard(*entityPtr.get());
                     writableContent.content.resize(writableContent.content.size() + 1, (char)event.text.unicode);

--- a/libs/GraphicECS/SFML/Systems/InputManagement.cpp
+++ b/libs/GraphicECS/SFML/Systems/InputManagement.cpp
@@ -86,10 +86,8 @@ namespace graphicECS::SFML::Systems
                 } else if (event.text.unicode == 13) {
                     auto guard = std::lock_guard(*entityPtr.get());
                     entityPtr->removeComponent<Selected>();
-                    if (entityPtr->contains<TextureName>()) {
-                        entityPtr->removeComponent<TextureName>();
-                        entityPtr->addComponent<TextureName>(GraphicsTextureResource::WRITABLE);
-                    }
+                    if (entityPtr->contains<TextureName>())
+                        entityPtr->getComponent<TextureName>().textureName = GraphicsTextureResource::WRITABLE;
                     return;
                 } else if (event.text.unicode != 8) {
                     auto guard = std::lock_guard(*entityPtr.get());

--- a/libs/GraphicECS/SFML/Systems/InputManagement.cpp
+++ b/libs/GraphicECS/SFML/Systems/InputManagement.cpp
@@ -260,8 +260,9 @@ namespace graphicECS::SFML::Systems
         std::vector<std::shared_ptr<Entity>> joined = world.joinEntities<Button, Position, Size>();
         RenderWindowResource &windowResource = world.getResource<RenderWindowResource>();
         sf::Vector2i mousePos = sf::Mouse::getPosition(windowResource.window);
+        bool actionRealised = false;
 
-        auto clickInButton = [this, &world, &mousePos](std::shared_ptr<Entity> entityPtr) {
+        auto clickInButton = [this, &world, &mousePos, &actionRealised](std::shared_ptr<Entity> entityPtr) {
             Position &pos = entityPtr.get()->getComponent<Position>();
             Size &size = entityPtr.get()->getComponent<Size>();
             DisplayState &state = entityPtr.get()->getComponent<DisplayState>();
@@ -270,13 +271,14 @@ namespace graphicECS::SFML::Systems
             bool sameHeigth = pos.x <= mousePos.x && mousePos.x <= pos.x + size.x;
             MenuStates &menuState = world.getResource<MenuStates>();
             MenuStates::menuState_e currState = menuState.currentState;
-            if (sameHeigth && sameWidth && state.displayState == currState) {
+            if (!actionRealised && sameHeigth && sameWidth && state.displayState == currState) {
                 entityPtr->getComponent<Button>().IsClicked = true;
                 ActionName &name = entityPtr.get()->getComponent<ActionName>();
                 ButtonActionMap &map = world.getResource<ButtonActionMap>();
 
                 std::function<void(World &, Entity &)> fct = map.actionList.find(name.actionName)->second;
                 fct(world, *(entityPtr.get()));
+                actionRealised = true;
             }
         };
         std::for_each(joined.begin(), joined.end(), clickInButton);


### PR DESCRIPTION
Add missing lock in writable clicking.

Dismissed the double taping functionality.

Add the enter keybind to unselect a writable.

Update the clicking functionality to avoid double click.